### PR TITLE
Rename package to sknnr and prep for alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ Thanks to Andrew Hudak (USDA Forest Service Rocky Mountain Research Station) for
 - Ohmann JL, Gregory MJ. 2002. Predictive Mapping of Forest Composition and Structure with Direct Gradient Analysis and Nearest Neighbor Imputation in Coastal Oregon, USA. Canadian Journal of Forest Research, 32, 725–741.
 
 [^imputation]: In a mapping context, kNN imputation refers to predicting feature values for a target from its k-nearest neighbors, and should not be confused with the usual `scikit-learn` usage as a pre-filling strategy for missing input data, e.g. [`KNNImputer`](https://scikit-learn.org/stable/modules/generated/sklearn.impute.KNNImputer.html).
-[^rfnn]: In [development](https://github.com/lemma-osu/scikit-learn-knn-regression/issues/24)!
+[^rfnn]: In [development](https://github.com/lemma-osu/sknnr/issues/24)!
 [^validation]: All estimators and parameters with equivalent functionality in `yaImpute` are tested to 3 decimal places against the R package.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: sknnr
-repo_url: https://github.com/lemma-osu/scikit-learn-knn-regression
-repo_name: lemma-osu/scikit-learn-knn-regression
+repo_url: https://github.com/lemma-osu/sknnr
+repo_name: lemma-osu/sknnr
 docs_dir: pages/
 
 nav:

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -1,12 +1,12 @@
 # Installation
 
-!!! info
-    `sknnr` will be available through PyPI and conda-forge once it is ready for release. Until then, you can install it from source.
+## From PyPI
 
-## From Source
+!!! info
+    `sknnr` is currently in pre-release on PyPI, so you'll need to use the `--pre` flag to install it.
 
 ```bash
-pip install git+https://github.com/lemma-osu/scikit-learn-knn-regression@main
+pip install sknnr --pre
 ```
 
 ## Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "scikit-learn-knn-regression"
+name = "sknnr"
 dynamic = ["version"]
 description = "Scikit-learn estimators for kNN regression methods"
 readme = "README.md"
@@ -20,8 +20,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/lemma-osu/scikit-learn-knn-regression"
-Source = "https://github.com/lemma-osu/scikit-learn-knn-regression"
+Homepage = "https://github.com/lemma-osu/sknnr"
+Source = "https://github.com/lemma-osu/sknnr"
 
 [tool.hatch.version]
 path = "src/sknnr/__about__.py"

--- a/src/sknnr/__about__.py
+++ b/src/sknnr/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.0"
+__version__ = "0.1.0-alpha"


### PR DESCRIPTION
Closes #61 by updating all references from `scikit-learn-knn-regression` to `sknnr`. Also preps for the `0.1.0-alpha` release by updating install instructions and the package version.