### PR TITLE
Update pre-commit versions and contributing doc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,13 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.278
+    rev: v0.3.2
     hooks:
       - id: ruff
-
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-      - id: black
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.9.0
     hooks:
       - id: mypy
-        exclude: ^tests/|^setup.py
+        exclude: ^tests/
         args: [--ignore-missing-imports]

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -23,24 +23,24 @@ This will install development dependencies in an isolated environment and drop y
 Use [pre-commit](https://pre-commit.com/) to run linting, type-checking, and formatting:
 
 ```bash
-$ pre-commit run --all-files
+$ hatch run pre-commit run --all-files
 ```
 
 ...or install it to run automatically before every commit with:
 
 ```bash
-$ pre-commit install
+$ hatch run pre-commit install
 ```
 
-You can run pre-commit hooks separately and pass additional arguments to them. For example, to run `black` on a single file:
+You can run pre-commit hooks separately and pass additional arguments to them. For example, to run `ruff-format` on a single file:
 
 ```bash
-$ pre-commit run black --files=src/sknnr/_base.py
+$ hatch run pre-commit run ruff-format --files=src/sknnr/_base.py
 ```
 
 ### Testing
 
-Unit tests are *not* run by `pre-commit`, but can be run manually using `hatch` [scripts](https://hatch.pypa.io/latest/config/environment/overview/#scripts):
+Unit tests are _not_ run by `pre-commit`, but can be run manually using `hatch` [scripts](https://hatch.pypa.io/latest/config/environment/overview/#scripts):
 
 ```bash
 $ hatch run test:all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = ["pre-commit"]
 dependencies = ["pytest", "pytest-cov", "pandas"]
 
 [tool.hatch.envs.test.scripts]
-all = "pytest {args}"
-coverage = "pytest --cov=src/sknnr {args}"
+all = "pytest . {args} --doctest-modules"
+coverage = "pytest . --cov=src/sknnr {args} --doctest-modules"
 
 [tool.hatch.envs.docs]
 dependencies = ["mkdocs", "mkdocs-material", "mkdocstrings[python]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,9 @@ license = ""
 requires-python = ">=3.8"
 authors = [
     { name = "Matt Gregory", email = "matt.gregory@oregonstate.edu" },
-    { name = "Aaron Zuspan", email = "aaron.zuspan@oregonstate.edu" }
+    { name = "Aaron Zuspan", email = "aaron.zuspan@oregonstate.edu" },
 ]
-dependencies = [
-    "numpy",
-    "scikit-learn>=1.2",
-    "scipy",
-]
+dependencies = ["numpy", "scikit-learn>=1.2", "scipy"]
 
 [project.urls]
 Homepage = "https://github.com/lemma-osu/sknnr"
@@ -30,32 +26,20 @@ path = "src/sknnr/__about__.py"
 packages = ["src/sknnr"]
 
 [tool.hatch.build.targets.sdist]
-include = [
-    "/src",
-]
+include = ["/src"]
 
 [tool.hatch.envs.default]
-dependencies = [
-    "pre-commit",
-]
+dependencies = ["pre-commit"]
 
 [tool.hatch.envs.test]
-dependencies = [
-    "pytest",
-    "pytest-cov",
-    "pandas"
-]
+dependencies = ["pytest", "pytest-cov", "pandas"]
 
 [tool.hatch.envs.test.scripts]
 all = "pytest {args}"
 coverage = "pytest --cov=src/sknnr {args}"
 
 [tool.hatch.envs.docs]
-dependencies = [
-    "mkdocs",
-    "mkdocs-material",
-    "mkdocstrings[python]"
-]
+dependencies = ["mkdocs", "mkdocs-material", "mkdocstrings[python]"]
 
 [tool.hatch.envs.docs.scripts]
 serve = "mkdocs serve --config-file docs/mkdocs.yml --watch ./README.md"
@@ -69,9 +53,25 @@ markers = [
 
 [tool.ruff]
 target-version = "py38"
-select = ["E", "I", "F", "B", "FA", "UP", "ISC", "PT", "NPY", "Q", "RET", "SIM", "PERF"]
 fix = true
 show-fixes = true
 
-[tool.ruff.isort]
+[tool.ruff.lint]
+select = [
+    "E",
+    "I",
+    "F",
+    "B",
+    "FA",
+    "UP",
+    "ISC",
+    "PT",
+    "NPY",
+    "Q",
+    "RET",
+    "SIM",
+    "PERF",
+]
+
+[tool.ruff.lint.isort]
 known-first-party = ["sknnr"]

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -4,7 +4,7 @@ import csv
 import sys
 from dataclasses import dataclass
 from importlib import resources
-from typing import TYPE_CHECKING, TextIO
+from typing import IO, TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
@@ -54,7 +54,7 @@ def _dataset_as_frame(dataset: Dataset) -> Dataset:
     )
 
 
-def _open_text(module_name: str, file_name: str) -> TextIO:
+def _open_text(module_name: str, file_name: str) -> IO[str]:
     """Open a file as text.
 
     This is a compatibility port for importlib.resources.open_text, which is deprecated
@@ -68,7 +68,7 @@ def _open_text(module_name: str, file_name: str) -> TextIO:
 
 def _load_csv_data(
     file_name: str,
-) -> tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.unicode_]]:
+) -> tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.str_]]:
     """Load data from a CSV file in the data module.
 
     Notes


### PR DESCRIPTION
Per changes made in [`sknnr-spatial`](https://github.com/lemma-osu/sknnr-spatial/commit/1da7ceaf4af1384228a704859d126cc08855752b), update the pre-commit versions to latest versions. 
- `ruff: v0.3.2`
- `mypy: v1.9.0`

In addition, remove the use of `black` as a pre-commit hook and instead rely on `ruff-format`.  Also, update `contributing.md` to show command use with `hatch` and to align it with the contributing guide for `sknnr-spatial`. 