### PR TITLE
Expose functions from `datasets` module in public API

### DIFF
--- a/src/sknnr/datasets/__init__.py
+++ b/src/sknnr/datasets/__init__.py
@@ -1,3 +1,13 @@
-from sknnr.datasets._base import load_moscow_stjoes, load_swo_ecoplot
+from sknnr.datasets._base import (
+    load_csv_data,
+    load_dataset_from_csv_filenames,
+    load_moscow_stjoes,
+    load_swo_ecoplot,
+)
 
-__all__ = ["load_moscow_stjoes", "load_swo_ecoplot"]
+__all__ = [
+    "load_csv_data",
+    "load_dataset_from_csv_filenames",
+    "load_moscow_stjoes",
+    "load_swo_ecoplot",
+]

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import sys
+import types
 from dataclasses import dataclass
 from importlib import resources
 from typing import IO, TYPE_CHECKING
@@ -54,7 +55,7 @@ def _dataset_as_frame(dataset: Dataset) -> Dataset:
     )
 
 
-def _open_text(module_name: str, file_name: str) -> IO[str]:
+def _open_text(module_name: str | types.ModuleType, file_name: str) -> IO[str]:
     """Open a file as text.
 
     This is a compatibility port for importlib.resources.open_text, which is deprecated
@@ -67,9 +68,7 @@ def _open_text(module_name: str, file_name: str) -> IO[str]:
 
 
 def load_csv_data(
-    file_name: str,
-    *,
-    data_module: str = DATA_MODULE,
+    file_name: str, *, data_module: str | types.ModuleType = DATA_MODULE
 ) -> tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.str_]]:
     """Load data from a CSV file from the specified data_module.
 
@@ -112,7 +111,7 @@ def load_dataset_from_csv_filenames(
     target_filename: str,
     return_X_y: bool = False,
     as_frame: bool = False,
-    data_module: str = DATA_MODULE,
+    data_module: str | types.ModuleType = DATA_MODULE,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]] | Dataset:
     """Load separate data and target CSV files into a dataset or paired NumPy arrays.
 

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -68,15 +68,15 @@ def _open_text(module_name: str | types.ModuleType, file_name: str) -> IO[str]:
 
 
 def load_csv_data(
-    file_name: str, *, data_module: str | types.ModuleType = DATA_MODULE
+    file_name: str, *, module_name: str | types.ModuleType = DATA_MODULE
 ) -> tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.str_]]:
-    """Load data from a CSV file from the specified data_module.
+    """Load data from a CSV file from the specified module_name.
 
     Parameters
     ----------
     file_name: str, required
-        The filename of the CSV file to load from `data_module/file_name`.
-    data_module: str or module, default='sknnr.datasets.data'
+        The filename of the CSV file to load from `module_name/file_name`.
+    module_name: str or module, default='sknnr.datasets.data'
         The module where the data file is located.
 
     Returns
@@ -93,7 +93,7 @@ def load_csv_data(
     The CSV must be formatted with plot IDs in the first column and data values in the
     remaining columns. The first row must contain the column names.
     """
-    with _open_text(data_module, file_name) as csv_file:
+    with _open_text(module_name, file_name) as csv_file:
         data_file = csv.reader(csv_file)
         headers = next(data_file)
         rows = list(iter(data_file))
@@ -111,7 +111,7 @@ def load_dataset_from_csv_filenames(
     target_filename: str,
     return_X_y: bool = False,
     as_frame: bool = False,
-    data_module: str | types.ModuleType = DATA_MODULE,
+    module_name: str | types.ModuleType = DATA_MODULE,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]] | Dataset:
     """Load separate data and target CSV files into a dataset or paired NumPy arrays.
 
@@ -128,7 +128,7 @@ def load_dataset_from_csv_filenames(
         DataFrames instead of NumPy arrays. The `frame` attribute will also be added as
         a DataFrame with the dataset index. Pandas must be installed for this
         option.
-    data_module: str or module, default='sknnr.datasets.data'
+    module_name: str or module, default='sknnr.datasets.data'
         The module where the data files are located.
 
     Returns
@@ -144,10 +144,10 @@ def load_dataset_from_csv_filenames(
     The plot IDs in each file are expected to match and be in the same order.
     """
     index, data, feature_names = load_csv_data(
-        file_name=data_filename, data_module=data_module
+        file_name=data_filename, module_name=module_name
     )
     _, target, target_names = load_csv_data(
-        file_name=target_filename, data_module=data_module
+        file_name=target_filename, module_name=module_name
     )
 
     dataset = Dataset(

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -66,17 +66,35 @@ def _open_text(module_name: str, file_name: str) -> IO[str]:
     return resources.open_text(module_name, file_name)
 
 
-def _load_csv_data(
+def load_csv_data(
     file_name: str,
+    *,
+    data_module: str = DATA_MODULE,
 ) -> tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.str_]]:
-    """Load data from a CSV file in the data module.
+    """Load data from a CSV file from the specified data_module.
+
+    Parameters
+    ----------
+    file_name: str, required
+        The filename of the CSV file to load from `data_module/file_name`.
+    data_module: str or module, default='sknnr.datasets.data'
+        The module where the data file is located.
+
+    Returns
+    -------
+    index: ndarray
+        The plot IDs from the first column of the CSV file.
+    data: ndarray
+        The data values from the remaining columns of the CSV file.
+    data_names: ndarray
+        The column names from the first row of the CSV file.
 
     Notes
     -----
     The CSV must be formatted with plot IDs in the first column and data values in the
     remaining columns. The first row must contain the column names.
     """
-    with _open_text(DATA_MODULE, file_name) as csv_file:
+    with _open_text(data_module, file_name) as csv_file:
         data_file = csv.reader(csv_file)
         headers = next(data_file)
         rows = list(iter(data_file))
@@ -88,12 +106,13 @@ def _load_csv_data(
     return index, data, data_names
 
 
-def _load_dataset_from_csv_filenames(
+def load_dataset_from_csv_filenames(
     *,
     data_filename: str,
     target_filename: str,
     return_X_y: bool = False,
     as_frame: bool = False,
+    data_module: str = DATA_MODULE,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]] | Dataset:
     """Load separate data and target CSV files into a dataset or paired NumPy arrays.
 
@@ -110,6 +129,8 @@ def _load_dataset_from_csv_filenames(
         DataFrames instead of NumPy arrays. The `frame` attribute will also be added as
         a DataFrame with the dataset index. Pandas must be installed for this
         option.
+    data_module: str or module, default='sknnr.datasets.data'
+        The module where the data files are located.
 
     Returns
     -------
@@ -123,8 +144,12 @@ def _load_dataset_from_csv_filenames(
     in the remaining columns. The first row in each file must contain the column names.
     The plot IDs in each file are expected to match and be in the same order.
     """
-    index, data, feature_names = _load_csv_data(file_name=data_filename)
-    _, target, target_names = _load_csv_data(file_name=target_filename)
+    index, data, feature_names = load_csv_data(
+        file_name=data_filename, data_module=data_module
+    )
+    _, target, target_names = load_csv_data(
+        file_name=target_filename, data_module=data_module
+    )
 
     dataset = Dataset(
         index=index,
@@ -179,7 +204,7 @@ def load_moscow_stjoes(
     Rocky Mountain Research Station.
     https://www.fs.usda.gov/rds/archive/Catalog/RDS-2010-0012
     """
-    return _load_dataset_from_csv_filenames(
+    return load_dataset_from_csv_filenames(
         data_filename="moscow_env.csv",
         target_filename="moscow_spp.csv",
         return_X_y=return_X_y,
@@ -229,7 +254,7 @@ def load_swo_ecoplot(
     Field guide to the forested plant associations of southwestern Oregon.
     USDA Forest Service. Pacific Northwest Region, Technical Paper R6-NR-ECOL-TP-17-96.
     """
-    return _load_dataset_from_csv_filenames(
+    return load_dataset_from_csv_filenames(
         data_filename="swo_ecoplot_env.csv",
         target_filename="swo_ecoplot_spp.csv",
         return_X_y=return_X_y,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 
-from sknnr.datasets import load_moscow_stjoes, load_swo_ecoplot
+from sknnr.datasets import load_csv_data, load_moscow_stjoes, load_swo_ecoplot
 
 
 @dataclass
@@ -26,6 +26,20 @@ CONFIGURATIONS = {
         load_function=load_swo_ecoplot, n_samples=3005, n_targets=25, n_features=18
     ),
 }
+
+
+def test_passing_module_type():
+    """Test that passing a module type to load_csv_data works."""
+    import sknnr.datasets.data as data_module
+
+    load_csv_data("moscow_env.csv", data_module=data_module)
+
+
+def test_incorrect_module_raises_on_load_csv():
+    """Test that load_csv_data raises when given an invalid module name."""
+    invalid_module = "sknnr.datasets.invalid_module"
+    with pytest.raises(ModuleNotFoundError, match="No module named"):
+        load_csv_data("moscow_env.csv", data_module=invalid_module)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -32,14 +32,14 @@ def test_passing_module_type():
     """Test that passing a module type to load_csv_data works."""
     import sknnr.datasets.data as data_module
 
-    load_csv_data("moscow_env.csv", data_module=data_module)
+    load_csv_data("moscow_env.csv", module_name=data_module)
 
 
 def test_incorrect_module_raises_on_load_csv():
     """Test that load_csv_data raises when given an invalid module name."""
     invalid_module = "sknnr.datasets.invalid_module"
     with pytest.raises(ModuleNotFoundError, match="No module named"):
-        load_csv_data("moscow_env.csv", data_module=invalid_module)
+        load_csv_data("moscow_env.csv", module_name=invalid_module)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #68 by adding `load_csv_data` and `load_dataset_from_csv_filenames` to the public API.  `data_module` is now passed as a keyword argument to both functions and defaults to `sknnr.datasets.data`.

- `data_module` in both functions can be passed as either a string (e.g. "sknnr.datasets.data") or as a module object
- Rudimentary tests on `load_csv_data`