### PR TITLE
Fix `r2_score` port test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install hatch
 
+      - name: List dependencies
+        run: hatch run pip freeze
+
       - name: Run tests
         run: hatch run test:all
   lint:

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -102,7 +102,7 @@ def test_score_independent(result, n_components, weighted):
     predicted = (
         dataset.ref_predicted_weighted if weighted else dataset.ref_predicted_unweighted
     )
-    expected_score = r2_score(dataset.y_train, predicted).mean()
+    expected_score = r2_score(dataset.y_train, predicted)
 
     hyperparams = dict(n_neighbors=5, weights=weights)
     hyperparams.update(


### PR DESCRIPTION
As part of using the [Array API](https://github.com/scikit-learn/scikit-learn/pull/27904) for `r2_score`, the return value of `r2_score` is now cast explicitly as a `float` rather than `np.float64` when it is a scalar value.

From [this doc](https://github.com/scikit-learn/scikit-learn/blob/c44457af96a924683b6a65bd3fd6c285043bdec6/doc/modules/array_api.rst?plain=1#L138-L152):

> Note however that scoring functions that return scalar values return Python scalars (typically a `float` instance) instead of an array scalar value.

In `test_port.test_score_independent`, we were calling `r2_score` using the default `multioutput="uniform_average"` which was returning a single `np.float64`.  We were then mistakenly calling `.mean()` on this value which had not previously thrown an error because it was operating on a `np.float64`.  With the change in return type, this test now throws an error at `scikit-learn>=1.5`.

Simply removing `.mean()` corrects this test.