### PR TITLE
Switch to PEP440 compliant alpha tag

### DIFF
--- a/src/sknnr/__about__.py
+++ b/src/sknnr/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.0-alpha.1"
+__version__ = "0.1.0a1"


### PR DESCRIPTION
Overwrites #71 by switching from the semver-compliant `0.1.0-alpha.1` to the [PEP 440-compliant](https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers) `0.1.0a1` version specifier. I had hoped to stick with semver, but following PEP440 is enforced by PyPI, and it's probably best to keep our package version and tags consistent with the PyPI releases.