### PR TITLE
Specify all `__init__` params for MSN and GNN

### DIFF
--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Callable, Literal
 
 import numpy as np
 from sklearn.base import TransformerMixin
+from sklearn.metrics import DistanceMetric
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.utils.validation import _is_arraylike, check_is_fitted
+
+if TYPE_CHECKING:
+    from .transformers._base import ComponentReducerMixin
 
 
 class DFIndexCrosswalkMixin:
@@ -146,3 +153,37 @@ class TransformedKNeighborsRegressor(RawKNNRegressor, ABC):
             return_distance=return_distance,
             return_dataframe_index=return_dataframe_index,
         )
+
+
+class OrdinationKNeighborsRegressor(TransformedKNeighborsRegressor, ABC):
+    """
+    Subclass for transformed KNeighbors regressors that apply ordination with
+    dimensionality reduction.
+    """
+
+    transformer_: ComponentReducerMixin
+
+    def __init__(
+        self,
+        n_neighbors: int = 5,
+        *,
+        n_components: int | None = None,
+        weights: Literal["uniform", "distance"] | Callable = "uniform",
+        algorithm: Literal["auto", "ball_tree", "kd_tree", "brute"] = "auto",
+        leaf_size: int = 30,
+        p: int = 2,
+        metric: str | Callable | DistanceMetric = "minkowski",
+        metric_params: dict | None = None,
+        n_jobs: int | None = None,
+    ):
+        super().__init__(
+            n_neighbors=n_neighbors,
+            weights=weights,
+            algorithm=algorithm,
+            leaf_size=leaf_size,
+            p=p,
+            metric=metric,
+            metric_params=metric_params,
+            n_jobs=n_jobs,
+        )
+        self.n_components = n_components

--- a/src/sknnr/_gnn.py
+++ b/src/sknnr/_gnn.py
@@ -1,12 +1,94 @@
+from __future__ import annotations
+
+from typing import Callable, Literal
+
 from sklearn.base import TransformerMixin
+from sklearn.metrics import DistanceMetric
 
 from ._base import TransformedKNeighborsRegressor, YFitMixin
 from .transformers import CCATransformer
 
 
 class GNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
-    def __init__(self, n_components=None, **kwargs):
-        super().__init__(**kwargs)
+    """
+    Regression using Gradient Nearest Neighbor (GNN) imputation.
+
+    The target is predicted by local interpolation of the targets associated with
+    the nearest neighbors in the training set, calculated in transformed Canonical
+    Correspondence Analysis (CCA) space.
+
+    See `sklearn.neighbors.KNeighborsRegressor` for more information on parameters
+    and implementation.
+
+    Parameters
+    ----------
+    n_neighbors : int, default=5
+        Number of neighbors to use by default for `kneighbors` queries.
+    n_components : int, default=None
+        Number of components to keep during CCA transformation. If None, all
+        components are kept. If n_components is less than the number of available
+        components, an error will be raised.
+    weights : {'uniform', 'distance'} or callable, default='uniform'
+        Weight function used in prediction.
+    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
+        Algorithm used to compute the nearest neighbors.
+    leaf_size : int, default=30
+        Leaf size passed to BallTree or KDTree.
+    p : int, default=2
+        Power parameter for the Minkowski metric.
+    metric : str or callable, default='minkowski'
+        The distance metric to use for the tree, calculated in CCA space.
+    metric_params : dict, default=None
+        Additional keyword arguments for the metric function.
+    n_jobs : int, default=None
+        The number of parallel jobs to run for neighbors search. None means 1 unless
+        in a joblib.parallel_backend context. -1 means using all processors.
+
+    Attributes
+    ----------
+    effective_metric_ : str or callable
+        The distance metric to use. It will be same as the `metric` parameter
+        or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
+        'minkowski' and `p` parameter set to 2.
+    effective_metric_params_ : dict
+        Additional keyword arguments for the metric function. For most metrics
+        will be same with `metric_params` parameter, but may also contain the
+        `p` parameter value if the `effective_metric_` attribute is set to
+        'minkowski'.
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Defined only when `X`
+        has feature names that are all strings.
+    n_samples_fit_ : int
+        Number of samples in the fitted data.
+    transformer_ : CCATransformer
+        Fitted transformer.
+    """
+
+    def __init__(
+        self,
+        n_neighbors: int = 5,
+        *,
+        n_components: int | None = None,
+        weights: Literal["uniform", "distance"] | Callable = "uniform",
+        algorithm: Literal["auto", "ball_tree", "kd_tree", "brute"] = "auto",
+        leaf_size: int = 30,
+        p: int = 2,
+        metric: str | Callable | DistanceMetric = "minkowski",
+        metric_params: dict | None = None,
+        n_jobs: int | None = None,
+    ):
+        super().__init__(
+            n_neighbors=n_neighbors,
+            weights=weights,
+            algorithm=algorithm,
+            leaf_size=leaf_size,
+            p=p,
+            metric=metric,
+            metric_params=metric_params,
+            n_jobs=n_jobs,
+        )
         self.n_components = n_components
 
     def _get_transformer(self) -> TransformerMixin:

--- a/src/sknnr/_gnn.py
+++ b/src/sknnr/_gnn.py
@@ -14,8 +14,8 @@ class GNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
     Regression using Gradient Nearest Neighbor (GNN) imputation.
 
     The target is predicted by local interpolation of the targets associated with
-    the nearest neighbors in the training set, calculated in transformed Canonical
-    Correspondence Analysis (CCA) space.
+    the nearest neighbors in the training set, with distances calculated in transformed
+    Canonical Correspondence Analysis (CCA) space.
 
     See `sklearn.neighbors.KNeighborsRegressor` for more information on parameters
     and implementation.
@@ -24,46 +24,51 @@ class GNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
     ----------
     n_neighbors : int, default=5
         Number of neighbors to use by default for `kneighbors` queries.
-    n_components : int, default=None
-        Number of components to keep during CCA transformation. If None, all
-        components are kept. If n_components is less than the number of available
+    n_components : int, optional
+        Number of components to keep during CCA transformation. If `None`, all
+        components are kept. If `n_components` is greater than the number of available
         components, an error will be raised.
     weights : {'uniform', 'distance'} or callable, default='uniform'
         Weight function used in prediction.
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
         Algorithm used to compute the nearest neighbors.
     leaf_size : int, default=30
-        Leaf size passed to BallTree or KDTree.
+        Leaf size passed to `BallTree` or `KDTree`.
     p : int, default=2
         Power parameter for the Minkowski metric.
     metric : str or callable, default='minkowski'
         The distance metric to use for the tree, calculated in CCA space.
     metric_params : dict, default=None
         Additional keyword arguments for the metric function.
-    n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search. None means 1 unless
-        in a joblib.parallel_backend context. -1 means using all processors.
+    n_jobs : int, optional
+        The number of parallel jobs to run for neighbors search. `None` means 1 unless
+        in a `joblib.parallel_backend` context. `-1` means using all processors.
 
     Attributes
     ----------
     effective_metric_ : str or callable
-        The distance metric to use. It will be same as the `metric` parameter
-        or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
-        'minkowski' and `p` parameter set to 2.
+        The distance metric to use. It will be same as the `metric` parameter or a
+        synonym of it, e.g. 'euclidean' if the `metric` parameter set to 'minkowski' and
+        `p` parameter set to 2.
     effective_metric_params_ : dict
-        Additional keyword arguments for the metric function. For most metrics
-        will be same with `metric_params` parameter, but may also contain the
-        `p` parameter value if the `effective_metric_` attribute is set to
-        'minkowski'.
+        Additional keyword arguments for the metric function. For most metrics will be
+        same with `metric_params` parameter, but may also contain the `p` parameter
+        value if the `effective_metric_` attribute is set to 'minkowski'.
     n_features_in_ : int
-        Number of features seen during :term:`fit`.
+        Number of features seen during `fit`.
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
-        Names of features seen during :term:`fit`. Defined only when `X`
-        has feature names that are all strings.
+        Names of features seen during `fit`. Defined only when `X` has feature names
+        that are all strings.
     n_samples_fit_ : int
         Number of samples in the fitted data.
     transformer_ : CCATransformer
         Fitted transformer.
+
+    References
+    ----------
+    Ohmann JL, Gregory MJ. 2002. Predictive Mapping of Forest Composition and Structure
+    with Direct Gradient Analysis and Nearest Neighbor Imputation in Coastal Oregon,
+    USA. Canadian Journal of Forest Research, 32, 725–741.
     """
 
     def __init__(

--- a/src/sknnr/_gnn.py
+++ b/src/sknnr/_gnn.py
@@ -1,15 +1,10 @@
-from __future__ import annotations
-
-from typing import Callable, Literal
-
 from sklearn.base import TransformerMixin
-from sklearn.metrics import DistanceMetric
 
-from ._base import TransformedKNeighborsRegressor, YFitMixin
+from ._base import OrdinationKNeighborsRegressor, YFitMixin
 from .transformers import CCATransformer
 
 
-class GNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
+class GNNRegressor(YFitMixin, OrdinationKNeighborsRegressor):
     """
     Regression using Gradient Nearest Neighbor (GNN) imputation.
 
@@ -70,31 +65,6 @@ class GNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
     with Direct Gradient Analysis and Nearest Neighbor Imputation in Coastal Oregon,
     USA. Canadian Journal of Forest Research, 32, 725–741.
     """
-
-    def __init__(
-        self,
-        n_neighbors: int = 5,
-        *,
-        n_components: int | None = None,
-        weights: Literal["uniform", "distance"] | Callable = "uniform",
-        algorithm: Literal["auto", "ball_tree", "kd_tree", "brute"] = "auto",
-        leaf_size: int = 30,
-        p: int = 2,
-        metric: str | Callable | DistanceMetric = "minkowski",
-        metric_params: dict | None = None,
-        n_jobs: int | None = None,
-    ):
-        super().__init__(
-            n_neighbors=n_neighbors,
-            weights=weights,
-            algorithm=algorithm,
-            leaf_size=leaf_size,
-            p=p,
-            metric=metric,
-            metric_params=metric_params,
-            n_jobs=n_jobs,
-        )
-        self.n_components = n_components
 
     def _get_transformer(self) -> TransformerMixin:
         return CCATransformer(self.n_components)

--- a/src/sknnr/_msn.py
+++ b/src/sknnr/_msn.py
@@ -1,12 +1,94 @@
+from __future__ import annotations
+
+from typing import Callable, Literal
+
 from sklearn.base import TransformerMixin
+from sklearn.metrics import DistanceMetric
 
 from ._base import TransformedKNeighborsRegressor, YFitMixin
 from .transformers import CCorATransformer
 
 
 class MSNRegressor(YFitMixin, TransformedKNeighborsRegressor):
-    def __init__(self, n_components=None, **kwargs):
-        super().__init__(**kwargs)
+    """
+    Regression using Most Similar Neighbor (MSN) imputation.
+
+    The target is predicted by local interpolation of the targets associated with
+    the nearest neighbors in the training set, calculated in transformed Canonical
+    Correlation Analysis (CCorA) space.
+
+    See `sklearn.neighbors.KNeighborsRegressor` for more information on parameters
+    and implementation.
+
+    Parameters
+    ----------
+    n_neighbors : int, default=5
+        Number of neighbors to use by default for `kneighbors` queries.
+    n_components : int, default=None
+        Number of components to keep during CCorA transformation. If None, all
+        components are kept. If n_components is less than the number of available
+        components, an error will be raised.
+    weights : {'uniform', 'distance'} or callable, default='uniform'
+        Weight function used in prediction.
+    algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
+        Algorithm used to compute the nearest neighbors.
+    leaf_size : int, default=30
+        Leaf size passed to BallTree or KDTree.
+    p : int, default=2
+        Power parameter for the Minkowski metric.
+    metric : str or callable, default='minkowski'
+        The distance metric to use for the tree, calculated in CCorA space.
+    metric_params : dict, default=None
+        Additional keyword arguments for the metric function.
+    n_jobs : int, default=None
+        The number of parallel jobs to run for neighbors search. None means 1 unless
+        in a joblib.parallel_backend context. -1 means using all processors.
+
+    Attributes
+    ----------
+    effective_metric_ : str or callable
+        The distance metric to use. It will be same as the `metric` parameter
+        or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
+        'minkowski' and `p` parameter set to 2.
+    effective_metric_params_ : dict
+        Additional keyword arguments for the metric function. For most metrics
+        will be same with `metric_params` parameter, but may also contain the
+        `p` parameter value if the `effective_metric_` attribute is set to
+        'minkowski'.
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Defined only when `X`
+        has feature names that are all strings.
+    n_samples_fit_ : int
+        Number of samples in the fitted data.
+    transformer_ : CCorATransformer
+        Fitted transformer.
+    """
+
+    def __init__(
+        self,
+        n_neighbors: int = 5,
+        *,
+        n_components: int | None = None,
+        weights: Literal["uniform", "distance"] | Callable = "uniform",
+        algorithm: Literal["auto", "ball_tree", "kd_tree", "brute"] = "auto",
+        leaf_size: int = 30,
+        p: int = 2,
+        metric: str | Callable | DistanceMetric = "minkowski",
+        metric_params: dict | None = None,
+        n_jobs: int | None = None,
+    ):
+        super().__init__(
+            n_neighbors=n_neighbors,
+            weights=weights,
+            algorithm=algorithm,
+            leaf_size=leaf_size,
+            p=p,
+            metric=metric,
+            metric_params=metric_params,
+            n_jobs=n_jobs,
+        )
         self.n_components = n_components
 
     def _get_transformer(self) -> TransformerMixin:

--- a/src/sknnr/_msn.py
+++ b/src/sknnr/_msn.py
@@ -1,15 +1,10 @@
-from __future__ import annotations
-
-from typing import Callable, Literal
-
 from sklearn.base import TransformerMixin
-from sklearn.metrics import DistanceMetric
 
-from ._base import TransformedKNeighborsRegressor, YFitMixin
+from ._base import OrdinationKNeighborsRegressor, YFitMixin
 from .transformers import CCorATransformer
 
 
-class MSNRegressor(YFitMixin, TransformedKNeighborsRegressor):
+class MSNRegressor(YFitMixin, OrdinationKNeighborsRegressor):
     """
     Regression using Most Similar Neighbor (MSN) imputation.
 
@@ -69,31 +64,6 @@ class MSNRegressor(YFitMixin, TransformedKNeighborsRegressor):
     Moeur M, Stage AR. 1995. Most Similar Neighbor: An Improved Sampling Inference
     Procedure for Natural Resources Planning. Forest Science, 41(2), 337–359.
     """
-
-    def __init__(
-        self,
-        n_neighbors: int = 5,
-        *,
-        n_components: int | None = None,
-        weights: Literal["uniform", "distance"] | Callable = "uniform",
-        algorithm: Literal["auto", "ball_tree", "kd_tree", "brute"] = "auto",
-        leaf_size: int = 30,
-        p: int = 2,
-        metric: str | Callable | DistanceMetric = "minkowski",
-        metric_params: dict | None = None,
-        n_jobs: int | None = None,
-    ):
-        super().__init__(
-            n_neighbors=n_neighbors,
-            weights=weights,
-            algorithm=algorithm,
-            leaf_size=leaf_size,
-            p=p,
-            metric=metric,
-            metric_params=metric_params,
-            n_jobs=n_jobs,
-        )
-        self.n_components = n_components
 
     def _get_transformer(self) -> TransformerMixin:
         return CCorATransformer(self.n_components)

--- a/src/sknnr/_msn.py
+++ b/src/sknnr/_msn.py
@@ -32,7 +32,7 @@ class MSNRegressor(YFitMixin, OrdinationKNeighborsRegressor):
     p : int, default=2
         Power parameter for the Minkowski metric.
     metric : str or callable, default='minkowski'
-        The distance metric to use for the tree, calculated in CCA space.
+        The distance metric to use for the tree, calculated in CCorA space.
     metric_params : dict, default=None
         Additional keyword arguments for the metric function.
     n_jobs : int, optional

--- a/src/sknnr/_msn.py
+++ b/src/sknnr/_msn.py
@@ -14,8 +14,8 @@ class MSNRegressor(YFitMixin, TransformedKNeighborsRegressor):
     Regression using Most Similar Neighbor (MSN) imputation.
 
     The target is predicted by local interpolation of the targets associated with
-    the nearest neighbors in the training set, calculated in transformed Canonical
-    Correlation Analysis (CCorA) space.
+    the nearest neighbors in the training set, with distances calculated in transformed
+    Canonical Correlation Analysis (CCorA) space.
 
     See `sklearn.neighbors.KNeighborsRegressor` for more information on parameters
     and implementation.
@@ -24,46 +24,50 @@ class MSNRegressor(YFitMixin, TransformedKNeighborsRegressor):
     ----------
     n_neighbors : int, default=5
         Number of neighbors to use by default for `kneighbors` queries.
-    n_components : int, default=None
-        Number of components to keep during CCorA transformation. If None, all
-        components are kept. If n_components is less than the number of available
+    n_components : int, optional
+        Number of components to keep during CCorA transformation. If `None`, all
+        components are kept. If `n_components` is greater than the number of available
         components, an error will be raised.
     weights : {'uniform', 'distance'} or callable, default='uniform'
         Weight function used in prediction.
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
         Algorithm used to compute the nearest neighbors.
     leaf_size : int, default=30
-        Leaf size passed to BallTree or KDTree.
+        Leaf size passed to `BallTree` or `KDTree`.
     p : int, default=2
         Power parameter for the Minkowski metric.
     metric : str or callable, default='minkowski'
-        The distance metric to use for the tree, calculated in CCorA space.
+        The distance metric to use for the tree, calculated in CCA space.
     metric_params : dict, default=None
         Additional keyword arguments for the metric function.
-    n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search. None means 1 unless
-        in a joblib.parallel_backend context. -1 means using all processors.
+    n_jobs : int, optional
+        The number of parallel jobs to run for neighbors search. `None` means 1 unless
+        in a `joblib.parallel_backend` context. `-1` means using all processors.
 
     Attributes
     ----------
     effective_metric_ : str or callable
-        The distance metric to use. It will be same as the `metric` parameter
-        or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
-        'minkowski' and `p` parameter set to 2.
+        The distance metric to use. It will be same as the `metric` parameter or a
+        synonym of it, e.g. 'euclidean' if the `metric` parameter set to 'minkowski' and
+        `p` parameter set to 2.
     effective_metric_params_ : dict
-        Additional keyword arguments for the metric function. For most metrics
-        will be same with `metric_params` parameter, but may also contain the
-        `p` parameter value if the `effective_metric_` attribute is set to
-        'minkowski'.
+        Additional keyword arguments for the metric function. For most metrics will be
+        same with `metric_params` parameter, but may also contain the `p` parameter
+        value if the `effective_metric_` attribute is set to 'minkowski'.
     n_features_in_ : int
-        Number of features seen during :term:`fit`.
+        Number of features seen during `fit`.
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
-        Names of features seen during :term:`fit`. Defined only when `X`
-        has feature names that are all strings.
+        Names of features seen during `fit`. Defined only when `X` has feature names
+        that are all strings.
     n_samples_fit_ : int
         Number of samples in the fitted data.
     transformer_ : CCorATransformer
         Fitted transformer.
+
+    References
+    ----------
+    Moeur M, Stage AR. 1995. Most Similar Neighbor: An Improved Sampling Inference
+    Procedure for Natural Resources Planning. Forest Science, 41(2), 337–359.
     """
 
     def __init__(

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -4,6 +4,7 @@ import pytest
 from numpy.testing import assert_array_equal
 from numpy.typing import NDArray
 from sklearn import config_context
+from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.utils.estimator_checks import parametrize_with_checks
 from sklearn.utils.validation import NotFittedError
@@ -169,3 +170,14 @@ def test_yfit_affects_prediction(estimator, X_y_yfit):
 
     with pytest.raises(AssertionError):
         assert_array_equal(with_y_fit_pred, without_y_fit_pred)
+
+
+@pytest.mark.parametrize("estimator", TEST_ESTIMATORS)
+def test_gridsearchcv(estimator, X_y_yfit):
+    """Test that GridSearchCV works with all estimators."""
+    X, y, _ = X_y_yfit
+
+    param_grid = {"n_neighbors": [1, 3]}
+    gs = GridSearchCV(estimator(), param_grid=param_grid, cv=2)
+    gs.fit(X, y)
+    gs.predict(X)


### PR DESCRIPTION
This would close #74 by explicitly specifying all the inherited `__init__` parameters for `MSNRegressor` and `GNNRegressor` via the new `OrdinationKNeighborsRegressor` abstract base class, so that they can be used in a grid search. I also added a basic test to run `GridSearchCV` on all estimators.

@grovduck, while I was adding the init params, I figured I might as well write up docstrings for those estimators as well. I copied directly from `KNeighborsRegressor` for all the shared parameters and attributes, but had to wing it a little bit for the specifics. Could you give those a look and edit as needed? Also, should we add some references or any more implementation info?

~I also considered making a shared mixin class to avoid the duplicated `__init__` method - something like `ComponentReducerRegressorMixin` - but wanted to keep it simple for the first pass and get your thoughts. Worth abstracting that out? I didn't want to cause any confusion with the existing `ComponentReducerMixin` that's used for the transformers.~ Ended up doing this with `OrdinationKNeighborsRegressor`.