### PR TITLE
Add Hatch script for local Python matrix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ dependencies = ["pytest", "pytest-cov", "pandas"]
 all = "pytest . {args} --doctest-modules"
 coverage = "pytest . --cov=src/sknnr {args} --doctest-modules"
 
+[tool.hatch.envs.test_matrix]
+template = "test"
+
+[[tool.hatch.envs.test_matrix.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12"]
+
 [tool.hatch.envs.docs]
 dependencies = ["mkdocs", "mkdocs-material", "mkdocstrings[python]"]
 


### PR DESCRIPTION
Closes #64 by adding a `test_matrix` Hatch env for testing across Python versions (e.g. `hatch run test_matrix:all`).

@grovduck, I just copied the config from `synthetic-knn` to keep everything consistent, and will duplicate this in `sknnr-spatial` next.