### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .coverage
+dist/

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -11,7 +11,7 @@ pip install sknnr --pre
 
 ## Dependencies
 
-- Python >= 3.8
+- Python >= 3.9
 - scikit-learn >= 1.2
 - numpy
 - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Scikit-learn estimators for kNN regression methods"
 readme = "README.md"
 license = ""
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Matt Gregory", email = "matt.gregory@oregonstate.edu" },
     { name = "Aaron Zuspan", email = "aaron.zuspan@oregonstate.edu" },
@@ -52,7 +52,6 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py38"
 fix = true
 show-fixes = true
 

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import csv
-import sys
 import types
 from dataclasses import dataclass
 from importlib import resources
-from typing import IO, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
@@ -55,18 +54,6 @@ def _dataset_as_frame(dataset: Dataset) -> Dataset:
     )
 
 
-def _open_text(module_name: str | types.ModuleType, file_name: str) -> IO[str]:
-    """Open a file as text.
-
-    This is a compatibility port for importlib.resources.open_text, which is deprecated
-    in Python>=3.9. This function will be removed when support for Python 3.8 is
-    dropped.
-    """
-    if sys.version_info >= (3, 9):
-        return resources.files(module_name).joinpath(file_name).open("r")
-    return resources.open_text(module_name, file_name)
-
-
 def load_csv_data(
     file_name: str, *, module_name: str | types.ModuleType = DATA_MODULE
 ) -> tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.str_]]:
@@ -93,7 +80,7 @@ def load_csv_data(
     The CSV must be formatted with plot IDs in the first column and data values in the
     remaining columns. The first row must contain the column names.
     """
-    with _open_text(module_name, file_name) as csv_file:
+    with resources.files(module_name).joinpath(file_name).open("r") as csv_file:
         data_file = csv.reader(csv_file)
         headers = next(data_file)
         rows = list(iter(data_file))

--- a/tests/datasets.py
+++ b/tests/datasets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from importlib import resources
 
 import numpy as np
 import pandas as pd
@@ -8,7 +9,6 @@ from numpy.typing import NDArray
 from sklearn.model_selection import train_test_split
 
 from sknnr.datasets import load_moscow_stjoes
-from sknnr.datasets._base import _open_text
 
 TEST_DATA_MODULE = "tests.data"
 
@@ -90,5 +90,5 @@ def load_moscow_stjoes_results(
 
 def _load_test_data(filename: str) -> pd.DataFrame:
     """Load a test dataset from the tests/data directory."""
-    with _open_text(TEST_DATA_MODULE, filename) as fh:
+    with resources.files(TEST_DATA_MODULE).joinpath(filename).open("r") as fh:
         return pd.read_csv(fh)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -114,8 +114,9 @@ def test_load_dataset_as_xy_as_frame(configuration: DatasetConfiguration):
 )
 def test_asframe_raises_without_pandas(configuration: DatasetConfiguration):
     """Test that as_frame=True raises a helpful error if pandas is not installed."""
-    with mock.patch.dict(sys.modules, {"pandas": None}), pytest.raises(
-        ImportError, match="pip install pandas"
+    with (
+        mock.patch.dict(sys.modules, {"pandas": None}),
+        pytest.raises(ImportError, match="pip install pandas"),
     ):
         configuration.load_function(as_frame=True)
 


### PR DESCRIPTION
Raises the minimum supported Python to 3.9, in anticipation of end-of-life for 3.8 in a couple months.

That allowed us to remove an internal compatibility function and use the "new" parenthesized `with` block. Unrelated, I removed the `target-version` specifier to allow Ruff to infer it from `requires-python` and added the `dist` build directory to `.gitignore`.