### PR TITLE
Scikit-learn 1.6 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "sknnr"
 dynamic = ["version"]
 description = "Scikit-learn estimators for kNN regression methods"
 readme = "README.md"
-license = ""
 requires-python = ">=3.9"
 authors = [
     { name = "Matt Gregory", email = "matt.gregory@oregonstate.edu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ include = ["/src"]
 dependencies = ["pre-commit"]
 
 [tool.hatch.envs.test]
-dependencies = ["pytest", "pytest-cov", "pandas"]
+dependencies = ["scikit-learn>=1.6.0rc1", "pytest", "pytest-cov", "pandas"]
 
 [tool.hatch.envs.test.scripts]
 all = "pytest . {args} --doctest-modules"

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -21,6 +21,8 @@ def _validate_data(estimator, *, ensure_all_finite: bool = True, **kwargs):
     public utility function. This function wraps the utility function if available,
     and falls back to the method if not. `force_all_finite` was also renamed to
     `ensure_all_finite`.
+
+    TODO: Remove when sklearn < 1.6.0 support is dropped.
     """
     try:
         from sklearn.utils.validation import validate_data

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -13,6 +13,22 @@ if TYPE_CHECKING:
     from .transformers._base import ComponentReducerMixin
 
 
+def _validate_data(estimator, *args, **kwargs):
+    """
+    Compatibility wrapper around sklearn's _validate_data function.
+
+    scikit-learn >= 1.6.0 moved _validate_data from a method of BaseEstimator to a
+    public utility function. This function wraps the utility function if available,
+    and falls back to the method if not.
+    """
+    try:
+        from sklearn.utils.validation import validate_data
+    except ImportError:
+        return estimator._validate_data(*args, **kwargs)
+
+    return validate_data(estimator, *args, **kwargs)
+
+
 class DFIndexCrosswalkMixin:
     """Mixin to crosswalk array indices to dataframe indexes."""
 
@@ -130,7 +146,7 @@ class TransformedKNeighborsRegressor(RawKNNRegressor, ABC):
 
     def fit(self, X, y):
         """Fit using transformed feature data."""
-        self._validate_data(X, y, force_all_finite=True, multi_output=True)
+        _validate_data(self, X, y, ensure_all_finite=True, multi_output=True)
         self._set_dataframe_index_in(X)
         self._set_fitted_transformer(X, y)
 

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -13,20 +13,21 @@ if TYPE_CHECKING:
     from .transformers._base import ComponentReducerMixin
 
 
-def _validate_data(estimator, *args, **kwargs):
+def _validate_data(estimator, *, ensure_all_finite: bool = True, **kwargs):
     """
     Compatibility wrapper around sklearn's _validate_data function.
 
     scikit-learn >= 1.6.0 moved _validate_data from a method of BaseEstimator to a
     public utility function. This function wraps the utility function if available,
-    and falls back to the method if not.
+    and falls back to the method if not. `force_all_finite` was also renamed to
+    `ensure_all_finite`.
     """
     try:
         from sklearn.utils.validation import validate_data
     except ImportError:
-        return estimator._validate_data(*args, **kwargs)
+        return estimator._validate_data(force_all_finite=ensure_all_finite, **kwargs)
 
-    return validate_data(estimator, *args, **kwargs)
+    return validate_data(estimator, ensure_all_finite=ensure_all_finite, **kwargs)
 
 
 class DFIndexCrosswalkMixin:
@@ -122,7 +123,7 @@ class TransformedKNeighborsRegressor(RawKNNRegressor, ABC):
 
     def fit(self, X, y):
         """Fit using transformed feature data."""
-        _validate_data(self, X, y, ensure_all_finite=True, multi_output=True)
+        _validate_data(self, X=X, y=y, ensure_all_finite=True, multi_output=True)
         self._set_dataframe_index_in(X)
         self._set_fitted_transformer(X, y)
 

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -120,30 +120,6 @@ class TransformedKNeighborsRegressor(RawKNNRegressor, ABC):
         """Fit and store the transformer."""
         self.transformer_ = self._get_transformer().fit(X, y)
 
-    @property
-    def feature_names_in_(self):
-        return self.transformer_.feature_names_in_
-
-    @property
-    def n_features_in_(self):
-        return self.transformer_.n_features_in_
-
-    def _check_feature_names(self, X, *, reset):
-        """Override BaseEstimator._check_feature_names to prevent errors.
-
-        This check would fail during fitting because `feature_names_in_` stores original
-        names while X contains transformed names. We instead rely on the transformer to
-        check feature names and warn or raise for mismatches.
-        """
-        return
-
-    def _check_n_features(self, X, *, reset):
-        """Override BaseEstimator._check_n_features to prevent errors.
-
-        See _check_feature_names.
-        """
-        return
-
     def fit(self, X, y):
         """Fit using transformed feature data."""
         _validate_data(self, X, y, ensure_all_finite=True, multi_output=True)

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -154,6 +154,12 @@ class TransformedKNeighborsRegressor(RawKNNRegressor, ABC):
             return_dataframe_index=return_dataframe_index,
         )
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.regressor_tags.multi_label = True
+
+        return tags
+
 
 class OrdinationKNeighborsRegressor(TransformedKNeighborsRegressor, ABC):
     """

--- a/src/sknnr/_gnn.py
+++ b/src/sknnr/_gnn.py
@@ -69,10 +69,9 @@ class GNNRegressor(YFitMixin, OrdinationKNeighborsRegressor):
     def _get_transformer(self) -> TransformerMixin:
         return CCATransformer(self.n_components)
 
-    def _more_tags(self):
-        return {
-            "allow_nan": False,
-            "requires_fit": True,
-            "requires_y": True,
-            "multioutput": True,
-        }
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.target_tags.single_output = False
+        tags.target_tags.two_d_labels = True
+
+        return tags

--- a/src/sknnr/_gnn.py
+++ b/src/sknnr/_gnn.py
@@ -68,10 +68,3 @@ class GNNRegressor(YFitMixin, OrdinationKNeighborsRegressor):
 
     def _get_transformer(self) -> TransformerMixin:
         return CCATransformer(self.n_components)
-
-    def __sklearn_tags__(self):
-        tags = super().__sklearn_tags__()
-        tags.target_tags.single_output = False
-        tags.target_tags.two_d_labels = True
-
-        return tags

--- a/src/sknnr/_gnn.py
+++ b/src/sknnr/_gnn.py
@@ -70,36 +70,9 @@ class GNNRegressor(YFitMixin, OrdinationKNeighborsRegressor):
         return CCATransformer(self.n_components)
 
     def _more_tags(self):
-        unsupported_1d = "CCA requires 2D y arrays."
-
         return {
             "allow_nan": False,
             "requires_fit": True,
             "requires_y": True,
             "multioutput": True,
-            "_xfail_checks": {
-                "check_estimators_dtypes": unsupported_1d,
-                "check_dtype_object": unsupported_1d,
-                "check_estimators_fit_returns_self": unsupported_1d,
-                "check_pipeline_consistency": unsupported_1d,
-                "check_estimators_overwrite_params": unsupported_1d,
-                "check_fit_score_takes_y": unsupported_1d,
-                "check_estimators_pickle": unsupported_1d,
-                "check_regressors_train": unsupported_1d,
-                "check_regressor_data_not_an_array": unsupported_1d,
-                "check_regressors_no_decision_function": unsupported_1d,
-                "check_supervised_y_2d": unsupported_1d,
-                "check_regressors_int": unsupported_1d,
-                "check_methods_sample_order_invariance": unsupported_1d,
-                "check_methods_subset_invariance": unsupported_1d,
-                "check_dict_unchanged": unsupported_1d,
-                "check_dont_overwrite_parameters": unsupported_1d,
-                "check_fit_idempotent": unsupported_1d,
-                "check_fit_check_is_fitted": unsupported_1d,
-                "check_n_features_in": unsupported_1d,
-                "check_fit2d_predict1d": unsupported_1d,
-                "check_fit2d_1sample": unsupported_1d,
-                "check_estimators_nan_inf": unsupported_1d,
-                "check_regressor_multioutput": "Row sums must be greater than 0.",
-            },
         }

--- a/src/sknnr/_msn.py
+++ b/src/sknnr/_msn.py
@@ -67,9 +67,3 @@ class MSNRegressor(YFitMixin, OrdinationKNeighborsRegressor):
 
     def _get_transformer(self) -> TransformerMixin:
         return CCorATransformer(self.n_components)
-
-    def _more_tags(self):
-        return {
-            "multioutput": True,
-            "requires_y": True,
-        }

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -22,7 +22,7 @@ class StandardScalerWithDOF(StandardScaler):
 
         X = _validate_data(
             self,
-            X,
+            X=X,
             accept_sparse=False,
             dtype=FLOAT_DTYPES,
             ensure_all_finite="allow-nan",

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -5,6 +5,7 @@ from numpy.typing import NDArray
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
+from .._base import _validate_data
 from ._cca import CCA
 from ._ccora import CCorA
 
@@ -19,11 +20,12 @@ class StandardScalerWithDOF(StandardScaler):
     def fit(self, X, y=None):
         scaler = super().fit(X, y)
 
-        X = self._validate_data(
+        X = _validate_data(
+            self,
             X,
             accept_sparse=False,
             dtype=FLOAT_DTYPES,
-            force_all_finite="allow-nan",
+            ensure_all_finite="allow-nan",
             reset=False,
             ensure_min_samples=self.ddof + 1,
         )

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -47,7 +47,5 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.target_tags.required = True
-        tags.target_tags.single_output = False
-        tags.target_tags.two_d_labels = True
 
         return tags

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -2,17 +2,19 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
+from .._base import _validate_data
 from . import ComponentReducerMixin
 from ._cca import CCA
 
 
 class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     def fit(self, X, y):
-        X = self._validate_data(
+        X = _validate_data(
+            self,
             X,
             reset=True,
             dtype=FLOAT_DTYPES,
-            force_all_finite=True,
+            ensure_all_finite=True,
             ensure_min_features=2,
             ensure_min_samples=1,
         )
@@ -28,11 +30,12 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
 
     def transform(self, X, y=None):
         check_is_fitted(self)
-        X = self._validate_data(
+        X = _validate_data(
+            self,
             X,
             reset=False,
             dtype=FLOAT_DTYPES,
-            force_all_finite=True,
+            ensure_all_finite=True,
             ensure_min_features=2,
             ensure_min_samples=1,
         )

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -41,9 +41,10 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     def fit_transform(self, X, y):
         return self.fit(X, y).transform(X)
 
-    def _more_tags(self):
-        return {
-            "allow_nan": False,
-            "requires_fit": True,
-            "requires_y": True,
-        }
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.target_tags.required = True
+        tags.target_tags.single_output = False
+        tags.target_tags.two_d_labels = True
+
+        return tags

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -11,7 +11,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     def fit(self, X, y):
         X = _validate_data(
             self,
-            X,
+            X=X,
             reset=True,
             dtype=FLOAT_DTYPES,
             ensure_all_finite=True,
@@ -32,7 +32,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         check_is_fitted(self)
         X = _validate_data(
             self,
-            X,
+            X=X,
             reset=False,
             dtype=FLOAT_DTYPES,
             ensure_all_finite=True,

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -42,33 +42,8 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         return self.fit(X, y).transform(X)
 
     def _more_tags(self):
-        unsupported_1d = "CCA requires 2D y arrays."
-
         return {
             "allow_nan": False,
             "requires_fit": True,
             "requires_y": True,
-            "_xfail_checks": {
-                "check_estimators_dtypes": unsupported_1d,
-                "check_dtype_object": unsupported_1d,
-                "check_estimators_fit_returns_self": unsupported_1d,
-                "check_pipeline_consistency": unsupported_1d,
-                "check_estimators_overwrite_params": unsupported_1d,
-                "check_fit_score_takes_y": unsupported_1d,
-                "check_estimators_pickle": unsupported_1d,
-                "check_transformer_data_not_an_array": unsupported_1d,
-                "check_transformer_general": unsupported_1d,
-                "check_transformer_preserve_dtypes": unsupported_1d,
-                "check_methods_sample_order_invariance": unsupported_1d,
-                "check_methods_subset_invariance": unsupported_1d,
-                "check_dict_unchanged": unsupported_1d,
-                "check_dont_overwrite_parameters": unsupported_1d,
-                "check_fit_idempotent": unsupported_1d,
-                "check_fit_check_is_fitted": unsupported_1d,
-                "check_n_features_in": unsupported_1d,
-                "check_fit2d_predict1d": unsupported_1d,
-                "check_fit2d_1sample": unsupported_1d,
-                "check_estimators_nan_inf": unsupported_1d,
-                "check_requires_y_none": unsupported_1d,
-            },
         }

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -9,7 +9,7 @@ from ._ccora import CCorA
 
 class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     def fit(self, X, y):
-        _validate_data(self, X, reset=True)
+        _validate_data(self, X=X, reset=True)
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
 
         y = check_array(y, input_name="Y", ensure_2d=False, dtype=np.float64)
@@ -24,7 +24,7 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
 
     def transform(self, X, y=None):
         check_is_fitted(self)
-        _validate_data(self, X, reset=False, ensure_all_finite=True)
+        _validate_data(self, X=X, reset=False, ensure_all_finite=True)
         return self.scaler_.transform(X) @ self.projector_
 
     def fit_transform(self, X, y):

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -2,13 +2,14 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_array, check_is_fitted
 
+from .._base import _validate_data
 from . import ComponentReducerMixin, StandardScalerWithDOF
 from ._ccora import CCorA
 
 
 class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     def fit(self, X, y):
-        self._validate_data(X, reset=True)
+        _validate_data(self, X, reset=True)
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
 
         y = check_array(y, input_name="Y", ensure_2d=False, dtype=np.float64)
@@ -23,7 +24,7 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
 
     def transform(self, X, y=None):
         check_is_fitted(self)
-        self._validate_data(X, reset=False, force_all_finite=True)
+        _validate_data(self, X, reset=False, ensure_all_finite=True)
         return self.scaler_.transform(X) @ self.projector_
 
     def fit_transform(self, X, y):

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -9,7 +9,7 @@ from . import StandardScalerWithDOF
 class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     def fit(self, X, y=None):
         _validate_data(
-            self, X, ensure_all_finite="allow-nan", reset=True, ensure_min_features=2
+            self, X=X, ensure_all_finite="allow-nan", reset=True, ensure_min_features=2
         )
 
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
@@ -19,7 +19,7 @@ class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimat
 
     def transform(self, X, y=None):
         check_is_fitted(self)
-        _validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
+        _validate_data(self, X=X, ensure_all_finite="allow-nan", reset=False)
 
         return self.scaler_.transform(X) @ self.transform_
 

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -2,13 +2,14 @@ import numpy as np
 from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
+from .._base import _validate_data
 from . import StandardScalerWithDOF
 
 
 class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     def fit(self, X, y=None):
-        self._validate_data(
-            X, force_all_finite="allow-nan", reset=True, ensure_min_features=2
+        _validate_data(
+            self, X, ensure_all_finite="allow-nan", reset=True, ensure_min_features=2
         )
 
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
@@ -18,7 +19,7 @@ class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimat
 
     def transform(self, X, y=None):
         check_is_fitted(self)
-        self._validate_data(X, force_all_finite="allow-nan", reset=False)
+        _validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
 
         return self.scaler_.transform(X) @ self.transform_
 

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -25,5 +25,8 @@ class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimat
     def fit_transform(self, X, y=None):
         return self.fit(X, y).transform(X)
 
-    def _more_tags(self):
-        return {"allow_nan": True}
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True
+
+        return tags

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -26,6 +26,13 @@ TEST_ESTIMATORS = [
     GNNRegressor,
 ]
 
+TEST_TRANSFORMED_ESTIMATORS = [
+    EuclideanKNNRegressor,
+    MahalanobisKNNRegressor,
+    MSNRegressor,
+    GNNRegressor,
+]
+
 TEST_YFIT_ESTIMATORS = [MSNRegressor, GNNRegressor]
 
 
@@ -185,8 +192,6 @@ def test_estimators_support_dataframes(estimator):
     estimator = estimator().fit(X, y)
     estimator.predict(X)
 
-    assert_array_equal(getattr(estimator, "feature_names_in_", None), X.columns)
-
 
 @pytest.mark.parametrize("fit_names", [True, False])
 @pytest.mark.parametrize("estimator", TEST_ESTIMATORS)
@@ -258,3 +263,17 @@ def test_gridsearchcv(estimator, X_y_yfit):
     gs = GridSearchCV(estimator(), param_grid=param_grid, cv=2)
     gs.fit(X, y)
     gs.predict(X)
+
+
+@pytest.mark.parametrize("estimator", TEST_TRANSFORMED_ESTIMATORS)
+def test_n_features_in(estimator, X_y_yfit):
+    """
+    Test that estimators store the number of transformed features.
+    """
+    X, y, _ = X_y_yfit
+
+    est = estimator().fit(X, y)
+    transformed_features = est.transformer_.get_feature_names_out()
+
+    assert est.transformer_.n_features_in_ == X.shape[1]
+    assert est.n_features_in_ == len(transformed_features)

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -69,7 +69,6 @@ def get_estimator_xfail_checks(estimator) -> dict[str, str]:
             "check_dont_overwrite_parameters",
             "check_fit_idempotent",
             "check_fit_check_is_fitted",
-            "check_n_features_in",
             "check_fit2d_predict1d",
             "check_fit2d_1sample",
             "check_estimators_nan_inf",
@@ -78,7 +77,6 @@ def get_estimator_xfail_checks(estimator) -> dict[str, str]:
         row_sum_checks = [
             "check_regressor_multioutput",
             "check_readonly_memmap_input",
-            "check_n_features_in_after_fitting",
             "check_f_contiguous_array_estimator",
         ]
 

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -36,7 +36,7 @@ def get_estimator_xfail_checks(estimator) -> dict[str, str]:
     These are mostly due to sklearn using test data that our estimators aren't
     compatible with, e.g. 1D labels.
 
-    Requires sklearn 1.6.
+    Requires sklearn >= 1.6.
     """
     xfail_checks = {}
 

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -86,7 +86,7 @@ def get_estimator_xfail_checks(estimator) -> dict[str, str]:
         )
 
     if isinstance(estimator, (GNNRegressor, MSNRegressor)):
-        # These checks fail because the transformed estimators store the number
+        # These checks fail because the transformed estimators store the number of
         # transformed features rather than raw input features as expected by sklearn.
         n_features_in_checks = [
             "check_n_features_in_after_fitting",

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -26,7 +26,58 @@ TEST_ORDINATION_TRANSFORMERS = [
 ]
 
 
-@parametrize_with_checks([cls() for cls in TEST_TRANSFORMERS])
+def get_transformer_xfail_checks(transformer) -> dict[str, str]:
+    """
+    Return tests that are expected to fail with explanations.
+
+    These are mostly due to sklearn using test data that our estimators aren't
+    compatible with, e.g. 1D labels.
+
+    Requires sklearn 1.6.
+    """
+    xfail_checks = {}
+
+    if isinstance(transformer, CCATransformer):
+        # These checks fail due to input data constraints for the CCA ordination that
+        # aren't followed by the sklearn checks.
+        one_d_checks = [
+            "check_estimators_dtypes",
+            "check_dtype_object",
+            "check_estimators_fit_returns_self",
+            "check_pipeline_consistency",
+            "check_estimators_overwrite_params",
+            "check_fit_score_takes_y",
+            "check_estimators_pickle",
+            "check_transformer_data_not_an_array",
+            "check_transformer_general",
+            "check_transformer_preserve_dtypes",
+            "check_methods_sample_order_invariance",
+            "check_methods_subset_invariance",
+            "check_dict_unchanged",
+            "check_dont_overwrite_parameters",
+            "check_fit_idempotent",
+            "check_fit_check_is_fitted",
+            "check_n_features_in",
+            "check_fit2d_predict1d",
+            "check_fit2d_1sample",
+            "check_estimators_nan_inf",
+            "check_requires_y_none",
+            "check_readonly_memmap_input",
+            "check_n_features_in_after_fitting",
+            "check_f_contiguous_array_estimator",
+        ]
+
+        xfail_checks.update(
+            {check: "CCA requires 2D y arrays." for check in one_d_checks}
+        )
+
+    return xfail_checks
+
+
+@parametrize_with_checks(
+    [cls() for cls in TEST_TRANSFORMERS],
+    expected_failed_checks=get_transformer_xfail_checks,
+)
 def test_sklearn_transformer_checks(estimator, check):
     check(estimator)
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -33,7 +33,7 @@ def get_transformer_xfail_checks(transformer) -> dict[str, str]:
     These are mostly due to sklearn using test data that our estimators aren't
     compatible with, e.g. 1D labels.
 
-    Requires sklearn 1.6.
+    Requires sklearn >= 1.6.
     """
     xfail_checks = {}
 


### PR DESCRIPTION
Closes #78 by introducing compatibility fixes for [breaking changes in sklearn >= 1.6](https://scikit-learn.org/1.6/whats_new/v1.6.html#version-1-6-0), described below.

As far as our downstream packages, if anything relied on `feature_names_in_` or `n_features_in_` they would need to be updated, but I did a quick search and didn't see either show up in the code of `sknnr-spatial`, `synthetic-knn`, or `gee-knn-python`. 

## xfail estimator checks

Instead of marking our xfailing estimator checks in the estimator tags, they're now passed as arguments to [`parametrize_with_checks`](https://scikit-learn.org/1.6/modules/generated/sklearn.utils.estimator_checks.parametrize_with_checks.html#sklearn.utils.estimator_checks.parametrize_with_checks). I'm very happy with this change since it got a lot of testing details out of the public API, but it does mean that our tests aren't backwards compatible, so I've pinned the test environment to 1.6. It would be nice to be able to test older versions, but I couldn't think of a good solution to allow that. Might be worth a future PR, though.

## Tags

Tags are [now stored in `__sklearn_tags__`](https://scikit-learn.org/1.6/developers/develop.html#estimator-tags) using dataclasses instead of as a dictionary in `_more_tags`. This was a pretty simple switch, although I tried to re-evaluate the tags while making the switch to try to make sure they were still correct and not redundant with inherited tags. Those might be worth a closer look.

We *could* keep `_more_tags` for full backwards compatibility, but I don't think they're likely to be touched by users, so I'm not too worried about breaking that.

## `validate_data`

This changed from an estimator method to a utility function. For backwards compatibility, I wrapped that function and dispatch to the appropriate place.

## `n_features_in_` and `feature_names_in_`

This is the big change that I could really use some feedback on. A while back we decided that these attributes on the transformed estimators should correspond to the raw features that were passed in by the user, rather than the transformed features that are *actually* used to fit the estimator. In other words, if you fit a `GNNRegressor` with 20 features, it might actually be fit with 5 features in CCA space, but we would show the user the original 20 features rather than exposing the implementation.

I don't think that was the wrong choice, but it did add complexity since our inherited classes run internal checks against those features. To solve that, we *were* overriding `_check_feature_names` and `_check_n_features` to just skip the check, and indirectly deferring to the corresponding checks on the transformers, but with the switch in 1.6 to utility function checks over estimator method checks, that workaround was broken.

After spending some time thinking about this and trying to come up with new workarounds, the conclusion I reached is that we're fighting a losing battle by trying to trick `sklearn` and changing the meaning of those attributes. I'm suggesting (and implemented here) that we just fall back to the default behavior where our estimators store the transformed features that they were *actually* fit with, and their transformers store the raw features that *they* were fit with.

If we think this is still a concern for users, we could expose a new attribute `raw_features_in_` or point users to `estimator.transformer_.n_features_in_`, but my suspicion is that it would rare for users to rely on these attributes.