### PR TITLE
Tag fixes for `sklearn==1.6.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ include = ["/src"]
 dependencies = ["pre-commit"]
 
 [tool.hatch.envs.test]
-dependencies = ["scikit-learn>=1.6.0rc1", "pytest", "pytest-cov", "pandas"]
+dependencies = ["scikit-learn>=1.6.0", "pytest", "pytest-cov", "pandas"]
 
 [tool.hatch.envs.test.scripts]
 all = "pytest . {args} --doctest-modules"

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -149,12 +149,6 @@ class TransformedKNeighborsRegressor(RawKNNRegressor, ABC):
             return_dataframe_index=return_dataframe_index,
         )
 
-    def __sklearn_tags__(self):
-        tags = super().__sklearn_tags__()
-        tags.regressor_tags.multi_label = True
-
-        return tags
-
 
 class OrdinationKNeighborsRegressor(TransformedKNeighborsRegressor, ABC):
     """

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -72,6 +72,7 @@ def get_estimator_xfail_checks(estimator) -> dict[str, str]:
             "check_fit2d_predict1d",
             "check_fit2d_1sample",
             "check_estimators_nan_inf",
+            "check_positive_only_tag_during_fit",
         ]
 
         row_sum_checks = [

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -65,6 +65,7 @@ def get_transformer_xfail_checks(transformer) -> dict[str, str]:
             "check_readonly_memmap_input",
             "check_n_features_in_after_fitting",
             "check_f_contiguous_array_estimator",
+            "check_positive_only_tag_during_fit",
         ]
 
         xfail_checks.update(


### PR DESCRIPTION
There were a few more breaking changes between `sklearn==1.6.0rc1` and `1.6.0` (now released) which this resolves:

1. `multi_label` is no longer an attribute of `RegressorTags` (I've tried to find where this was changed to figure out the rationale, but didn't have any luck. Maybe it was never implemented but it just wasn't being checked before?).
2. `check_positive_only_tag_during_fit` was added, which uses 1D data that breaks CCA.

