### PR TITLE
Finalize estimator tags and fix sparse test failure

### DIFF
--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -149,6 +149,12 @@ class TransformedKNeighborsRegressor(RawKNNRegressor, ABC):
             return_dataframe_index=return_dataframe_index,
         )
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = False
+
+        return tags
+
 
 class OrdinationKNeighborsRegressor(TransformedKNeighborsRegressor, ABC):
     """

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -47,5 +47,6 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.target_tags.required = True
+        tags.target_tags.positive_only = True
 
         return tags

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -1,6 +1,5 @@
-import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_array, check_is_fitted
+from sklearn.utils.validation import check_is_fitted
 
 from .._base import _validate_data
 from . import ComponentReducerMixin, StandardScalerWithDOF
@@ -9,10 +8,9 @@ from ._ccora import CCorA
 
 class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     def fit(self, X, y):
-        _validate_data(self, X=X, reset=True)
+        _, y = _validate_data(self, X=X, y=y, reset=True, multi_output=True)
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
 
-        y = check_array(y, input_name="Y", ensure_2d=False, dtype=np.float64)
         if y.ndim == 1:
             y = y.reshape(-1, 1)
         y = StandardScalerWithDOF(ddof=1).fit_transform(y)
@@ -29,3 +27,9 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
 
     def fit_transform(self, X, y):
         return self.fit(X, y).transform(X)
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.target_tags.required = True
+
+        return tags


### PR DESCRIPTION
Closes #82 and #83

- CCA now correctly requires positive targets
- CCorA now correctly requires targets
- All estimators (other than `RawKNNRegressor`) now explicitly prohibit sparse data. This is a temporary measure to fix failing checks. A closer investigation of sparse support is needed.
- The addition of `target_tags.required` to CCorA triggered an estimator check `check_requires_y_none` which looks for an expected error message when passed `y=None`. That error is now correctly raised by passing y into `_validate_data`. This removed the need to separately check the y array. Note that we don't mutate `X` with the validation check as this will strip feature names that must be passed to `StandardScalerWithDOF`.

@grovduck, please check and confirm that I covered all the tag changes we discussed, thanks!

The updated boolean tags following these changes:

![image](https://github.com/user-attachments/assets/699df6e4-cdd8-46d2-ae58-f1f3a9df583c)
