### PR TITLE
Update precommit hooks to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.2
+    rev: v0.11.2
     hooks:
       - id: ruff
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         exclude: ^tests/

--- a/tests/datasets.py
+++ b/tests/datasets.py
@@ -70,7 +70,7 @@ def load_moscow_stjoes_results(
         f"{method}_moscow_trg_predicted_unweighted_k{k}{n_components_str}.csv"
     )
 
-    cols = [f"K{i+1}" for i in range(k)]
+    cols = [f"K{i + 1}" for i in range(k)]
 
     return KNNTestDataset(
         X_train=X_train,

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -112,7 +112,7 @@ def get_estimator_xfail_checks(estimator) -> dict[str, str]:
     return xfail_checks
 
 
-@pytest.fixture()
+@pytest.fixture
 def X_y_yfit() -> tuple[NDArray, NDArray, NDArray]:
     """Return X, y, and y_fit arrays for testing y_fit compatible estimators."""
     X, y = load_moscow_stjoes(return_X_y=True)


### PR DESCRIPTION
As with lemma-osu/sklearn-raster#52, this PR updates pre-commit hooks for `sknnr` and fixes [PT001](https://docs.astral.sh/ruff/rules/pytest-fixture-incorrect-parentheses-style/) issues.