### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,56 @@
+# Adapted from: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Publish to PyPI
+on:
+    push:
+        tags:
+            # Publish when a tag is pushed
+            - '*'
+
+jobs:
+    build:
+        name: Build distribution
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                persist-credentials: false
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: '3.x'
+
+            - name: Install hatch
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install hatch
+
+            - name: Build distribution
+              run: hatch build -c
+
+            - name: Store packages
+              uses: actions/upload-artifact@v4
+              with:
+                name: python-package-distributions
+                path: dist/
+                    
+    publish-to-pypi:
+        name: Publish to PyPI
+        runs-on: ubuntu-latest
+        needs:
+        - build
+        environment:
+            name: pypi
+            url: https://pypi.org/p/sknnr
+        permissions:
+            id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+        steps:
+        - name: Download dists
+          uses: actions/download-artifact@v4
+          with:
+            name: python-package-distributions
+            path: dist/
+        - name: Publish distribution to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -82,22 +82,13 @@ First, use `hatch` to [update the version number](https://hatch.pypa.io/latest/v
 $ hatch version [major|minor|patch|alpha|beta|rc|post|dev]
 ```
 
-Next, tag the release:
+Checkout `main` and confirm that it is up-to-date with the remote, including the bumped version. Finally, create and push the release tag.
 
 ```bash
+$ git checkout main
+$ git pull
 $ git tag "$(hatch version)"
 $ git push --tags
 ```
 
-Finally, [build](https://hatch.pypa.io/latest/build/#building) and [publish](https://hatch.pypa.io/latest/publish/#publishing) the release to PyPI with:
-
-```bash
-$ hatch build -c
-$ hatch publish
-```
-
-If needed, your PyPI API token can be passed as an argument to `hatch publish` with the username `__token__`:
-
-```bash
-hatch publish -a [api token] -u __token__
-```
+Pushing the updated tag will trigger [a workflow](https://github.com/lemma-osu/sknnr/actions/workflows/publish.yml) that publishes the release to PyPI.


### PR DESCRIPTION
This adds a workflow to automate publishing to PyPI whenever a new tag is pushed and updates the contributing guide with the relevant instructions.

See https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/.

@grovduck, I've added Github as a trusted publisher [on PyPI](https://pypi.org/manage/project/sknnr/settings/publishing/), so this should work next time that we need to make a release. Unfortunately, I don't think there's any good way to validate the workflow, but I'm reasonably confident it'll work as expected since I copied it directly from the [`eerepr` workflow](https://github.com/aazuspan/eerepr/actions/workflows/publish.yml) which ran successfully.

