### PR TITLE
Run CI tests in parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         run: hatch run pip freeze
 
       - name: Run tests
-        run: hatch run test:all
+        run: hatch run test:all -n 4
   lint:
     runs-on: ubuntu-latest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pytest",
     "pytest-cov",
     "pytest-regressions",
+    "pytest-xdist",
     "pandas",
 ]
 


### PR DESCRIPTION
Closes #94 by adding a test dependency on `pytest-xdist` and parallelizing CI tests. CI uses all 4 available threads (per [Github docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)), which decreased overall CI time from about 3.5 minutes to 2.25, based on just one run.

Local tests are still serial by default but can be run in parallel with (using 8 threads):

```
hatch run test:all -n 8
```

@grovduck, we could parallelize locally by default (i.e. `hatch run test:all` would always use `-n auto`), but I don't have strong feelings either way. As you mentioned in #94, using `auto` adds some additional overhead so we might always end up overriding it manually anyways. Let me know if you have a preference.