### PR TITLE
Use generic `TreeNodeTransformer` for forest-based node ID transformers

### DIFF
--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -135,7 +135,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
             ensure_min_features=1,
             ensure_min_samples=1,
         )
-        return np.hstack([rf.apply(X) for rf in self.estimators_])
+        return np.hstack([est.apply(X) for est in self.estimators_]).astype("int64")
 
     def fit_transform(self, X, y):
         return self.fit(X, y).transform(X)

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+from numpy.typing import NDArray
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_array, check_is_fitted
+
+from .._base import _validate_data
+from ..utils import get_feature_names_and_dtypes, is_nan_like, is_number_like_type
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
+    def _validate_and_promote_targets(
+        self, y: Any, target_info: dict[str, np.dtype | pd.CategoricalDtype]
+    ) -> list[NDArray]:
+        """
+        Given target names and types, validate and promote each target in `y`.
+
+        `y` is treated as a 2D array, where each column is a target with potentially
+        different dtypes between columns. Each target is first validated to have
+        no NaN-like values and then promoted to the minimum numpy dtype that
+        safely represents all elements (as previously captured in `target_info`).
+        Additionally, each target is validated to ensure no combination of
+        string-like and non-string-like elements is present.
+
+        Return the targets as a list of numpy arrays.
+        """
+        y = np.asarray(y, dtype=object)
+        if y.ndim == 1:
+            y = y.reshape(-1, 1)
+
+        v_is_nan_like = np.vectorize(is_nan_like)
+        targets = []
+        for i, (name, promoted_dtype) in enumerate(target_info.items()):
+            target = y[:, i]
+
+            # Perform strict validation of the target to identify NaN-like
+            # elements (None, np.nan, pd.NA).  We cannot use sklearn `check_array`
+            # with `ensure_all_finite=True`` and `dtype=None`, as None values
+            # go undetected and pd.NA values raise an error.
+            if np.any(v_is_nan_like(target)):
+                raise ValueError(f"Target {name} has NaN-like elements.")
+
+            # If the promoted dtype is categorical, promote the data to the
+            # minimum numpy dtype.  Numpy does not support categorical dtypes,
+            # but we need to retain the categorical dtype label to correctly route
+            # the target to a random forest classifier.
+            if str(promoted_dtype) == "category":
+                target = np.asarray(target.tolist())
+
+            # Check for targets with mixed numeric and non-numeric elements.
+            # Safe promotion of numeric types to other numeric types is
+            # allowed (e.g. bool to int, int to float), but potentially unsafe
+            # promotion from numeric to non-numeric types is not allowed
+            # (e.g. int to str, float to str).
+            elif np.issubdtype(promoted_dtype, np.str_) and (
+                non_string_types := {
+                    type(v) for v in target if not np.issubdtype(type(v), np.str_)
+                }
+            ):
+                raise ValueError(
+                    f"Target {name} has non-string types ({non_string_types}) "
+                    f"that cannot be safely converted to a string dtype "
+                    f"({promoted_dtype})."
+                )
+
+            # Otherwise, promote the target to the minimum numpy dtype
+            else:
+                target = target.astype(promoted_dtype)
+
+            # Check for any other issues with the target when paired with the
+            # estimator.
+            target = check_array(
+                target,
+                ensure_all_finite=True,
+                dtype=None,
+                ensure_2d=False,
+                estimator=self,
+            )
+            targets.append(target)
+
+        return targets
+
+    def _set_estimator_types(
+        self, target_info: dict[str, Any]
+    ) -> dict[str, Literal["regression", "classification"]]:
+        """Set the estimator type to use for each target in `y`."""
+
+        # TODO: Handle overrides from user based on names
+        # TODO: target_info.update(user_overrides)
+        return {
+            k: "regression" if is_number_like_type(v) else "classification"
+            for k, v in target_info.items()
+        }
+
+    def _fit(self, X, y, regressor_cls, classifier_cls, reg_kwargs, clf_kwargs):
+        _validate_data(self, X=X, reset=True)
+
+        # Get target names and minimum numpy dtypes for each target in `y`
+        target_info = get_feature_names_and_dtypes(y)
+
+        # Validate and promote targets within `y`
+        y = self._validate_and_promote_targets(y, target_info)
+
+        # Assign estimator types based on the target dtypes
+        self.estimator_type_dict_ = self._set_estimator_types(target_info)
+
+        # Create the estimators for each target in `y` and fit them
+        target_idx_to_estimator_type = {
+            i: v for i, (_, v) in enumerate(self.estimator_type_dict_.items())
+        }
+        self.estimators_ = [
+            regressor_cls(**reg_kwargs).fit(X, target)
+            if target_idx_to_estimator_type[i] == "regression"
+            else classifier_cls(**clf_kwargs).fit(X, target)
+            for i, target in enumerate(y)
+        ]
+        return self
+
+    @abstractmethod
+    def fit(self, X, y): ...
+
+    def transform(self, X):
+        check_is_fitted(self)
+        _validate_data(
+            self,
+            X=X,
+            reset=False,
+            ensure_min_features=1,
+            ensure_min_samples=1,
+        )
+        return np.hstack([rf.apply(X) for rf in self.estimators_])
+
+    def fit_transform(self, X, y):
+        return self.fit(X, y).transform(X)
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.target_tags.required = True
+        tags.transformer_tags.preserves_dtype = ["int64"]
+
+        return tags

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -280,10 +280,8 @@ def test_rfnode_transformer_non_default_parameterization(
     ).fit(X, y)
 
     # Check that both regression and classification forests are present
-    assert (
-        sum(list(v == "classification" for v in est.estimator_type_dict_.values())) >= 1
-    )
-    assert sum(list(v == "regression" for v in est.estimator_type_dict_.values())) >= 1
+    assert "classification" in est.estimator_type_dict_.values()
+    assert "regression" in est.estimator_type_dict_.values()
 
     # Confirm that the specialized parameters are set on the correct forests
     for rf in est.estimators_:

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -30,6 +30,18 @@ TEST_ORDINATION_TRANSFORMERS = [
     CCorATransformer,
 ]
 
+TEST_TREE_TRANSFORMERS = [
+    RFNodeTransformer,
+]
+
+# Mapping of tree node transformers to their corresponding sklearn forest types
+TREE_TRANSFORMER_FOREST_TYPES = {
+    RFNodeTransformer: {
+        "regression": RandomForestRegressor,
+        "classification": RandomForestClassifier,
+    },
+}
+
 
 def get_transformer_xfail_checks(transformer) -> dict[str, str]:
     """
@@ -188,18 +200,53 @@ def test_transformers_raise_out_of_range_n_components(transformer, n_components)
         transformer(n_components=n_components).fit(X, y)
 
 
-@pytest.mark.parametrize("x_type", ["array", "dataframe"])
-def test_rfnode_transformer_assigns_correct_forest_types(x_type):
-    """Test that the RFNodeTransformer returns the correct forest types."""
-    X, y = load_moscow_stjoes(return_X_y=True, as_frame=x_type == "dataframe")
-    est = RFNodeTransformer().fit(X, y)
+@pytest.mark.parametrize("transformer", TEST_TREE_TRANSFORMERS)
+def test_treenode_transformer_assigns_correct_forest_types(transformer):
+    """Test that the TreeNodeTransformer returns the correct forest types."""
+    X, y = load_moscow_stjoes(return_X_y=True, as_frame=False)
+
+    transformer_type_dict = TREE_TRANSFORMER_FOREST_TYPES[transformer]
+    clf_est_type = transformer_type_dict["classification"]
+    reg_est_type = transformer_type_dict["regression"]
+
+    est = transformer().fit(X, y)
     assert all(v == "regression" for v in est.estimator_type_dict_.values())
-    assert all(isinstance(forest, RandomForestRegressor) for forest in est.rfs_)
+    assert all(isinstance(forest, reg_est_type) for forest in est.estimators_)
 
     y_bool = y.astype("bool")
-    est = RFNodeTransformer().fit(X, y_bool)
+    est = transformer().fit(X, y_bool)
     assert all(v == "classification" for v in est.estimator_type_dict_.values())
-    assert all(isinstance(forest, RandomForestClassifier) for forest in est.rfs_)
+    assert all(isinstance(forest, clf_est_type) for forest in est.estimators_)
+
+
+@pytest.mark.parametrize("transformer", TEST_TREE_TRANSFORMERS)
+@pytest.mark.parametrize("y_wrapper", [pd.Series, np.asarray])
+@pytest.mark.parametrize("nan_like_value", [np.nan, None, pd.NA])
+def test_treenode_transformer_raises_on_nan_like_target(
+    transformer, y_wrapper, nan_like_value
+):
+    """Test that the TreeNodeTransformer raises on targets with NaN-like elements."""
+    X, y = load_moscow_stjoes(return_X_y=True)
+    y = y[:, 0].astype(object)
+    y[0] = nan_like_value
+    y = y_wrapper(y, dtype=object)
+    with pytest.raises(ValueError, match=r"Target \S+ has NaN-like elements"):
+        _ = transformer().fit(X, y)
+
+
+@pytest.mark.parametrize("transformer", TEST_TREE_TRANSFORMERS)
+@pytest.mark.parametrize("y_wrapper", [pd.Series, np.asarray])
+def test_treenode_transformer_raises_on_mixed_target(transformer, y_wrapper):
+    """
+    Test that the TreeNodeTransformer raises on targets with mixed
+    string/non-string data that cannot safely be promoted to a common type.
+    """
+    X, y = load_moscow_stjoes(return_X_y=True)
+    y = y[:, 0].astype(object)
+    y[-1] = "mixed"
+    y = y_wrapper(y, dtype=object)
+    with pytest.raises(ValueError, match=r"Target \S+ has non-string types"):
+        _ = transformer().fit(X, y)
 
 
 @pytest.mark.parametrize("criterion_reg", ["absolute_error"])
@@ -239,7 +286,7 @@ def test_rfnode_transformer_non_default_parameterization(
     assert len(list(v == "regression" for v in est.estimator_type_dict_.values())) >= 1
 
     # Confirm that the specialized parameters are set on the correct forests
-    for rf in est.rfs_:
+    for rf in est.estimators_:
         if isinstance(rf, RandomForestClassifier):
             assert rf.get_params()["criterion"] == criterion_clf
             assert rf.get_params()["max_features"] == max_features_clf
@@ -247,29 +294,3 @@ def test_rfnode_transformer_non_default_parameterization(
         else:
             assert rf.get_params()["criterion"] == criterion_reg
             assert rf.get_params()["max_features"] == max_features_reg
-
-
-@pytest.mark.parametrize("y_wrapper", [pd.Series, np.asarray])
-@pytest.mark.parametrize("nan_like_value", [np.nan, None, pd.NA])
-def test_rfnode_transformer_raises_on_nan_like_target(y_wrapper, nan_like_value):
-    """Test that the RFNodeTransformer raises on targets with NaN-like elements."""
-    X, y = load_moscow_stjoes(return_X_y=True)
-    y = y[:, 0].astype(object)
-    y[0] = nan_like_value
-    y = y_wrapper(y, dtype=object)
-    with pytest.raises(ValueError, match=r"Target \S+ has NaN-like elements"):
-        _ = RFNodeTransformer().fit(X, y)
-
-
-@pytest.mark.parametrize("y_wrapper", [pd.Series, np.asarray])
-def test_rfnode_transformer_raises_on_mixed_target(y_wrapper):
-    """
-    Test that the RFNodeTransformer raises on targets with mixed
-    string/non-string data that cannot safely be promoted to a common type.
-    """
-    X, y = load_moscow_stjoes(return_X_y=True)
-    y = y[:, 0].astype(object)
-    y[-1] = "mixed"
-    y = y_wrapper(y, dtype=object)
-    with pytest.raises(ValueError, match=r"Target \S+ has non-string types"):
-        _ = RFNodeTransformer().fit(X, y)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -193,12 +193,12 @@ def test_rfnode_transformer_assigns_correct_forest_types(x_type):
     """Test that the RFNodeTransformer returns the correct forest types."""
     X, y = load_moscow_stjoes(return_X_y=True, as_frame=x_type == "dataframe")
     est = RFNodeTransformer().fit(X, y)
-    assert all(v == "regression" for v in est.rf_type_dict_.values())
+    assert all(v == "regression" for v in est.estimator_type_dict_.values())
     assert all(isinstance(forest, RandomForestRegressor) for forest in est.rfs_)
 
     y_bool = y.astype("bool")
     est = RFNodeTransformer().fit(X, y_bool)
-    assert all(v == "classification" for v in est.rf_type_dict_.values())
+    assert all(v == "classification" for v in est.estimator_type_dict_.values())
     assert all(isinstance(forest, RandomForestClassifier) for forest in est.rfs_)
 
 
@@ -233,8 +233,10 @@ def test_rfnode_transformer_non_default_parameterization(
     ).fit(X, y)
 
     # Check that both regression and classification forests are present
-    assert len(list(v == "classification" for v in est.rf_type_dict_.values())) >= 1
-    assert len(list(v == "regression" for v in est.rf_type_dict_.values())) >= 1
+    assert (
+        len(list(v == "classification" for v in est.estimator_type_dict_.values())) >= 1
+    )
+    assert len(list(v == "regression" for v in est.estimator_type_dict_.values())) >= 1
 
     # Confirm that the specialized parameters are set on the correct forests
     for rf in est.rfs_:

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -281,9 +281,9 @@ def test_rfnode_transformer_non_default_parameterization(
 
     # Check that both regression and classification forests are present
     assert (
-        len(list(v == "classification" for v in est.estimator_type_dict_.values())) >= 1
+        sum(list(v == "classification" for v in est.estimator_type_dict_.values())) >= 1
     )
-    assert len(list(v == "regression" for v in est.estimator_type_dict_.values())) >= 1
+    assert sum(list(v == "regression" for v in est.estimator_type_dict_.values())) >= 1
 
     # Confirm that the specialized parameters are set on the correct forests
     for rf in est.estimators_:


### PR DESCRIPTION
This PR introduces a base class for transformers that capture tree node IDs during `transform`.  Currently, this is only `RFNodeTransformer`, but #96 proposes other transformers with nearly duplicate needed functionality (gradient boosting and histogram-based gradient boosting).  This represents an incremental step to introducing those transformers and their accompanying NN-based estimators by doing the following:

- Creating a new abstract `TreeNodeTransformer` class that implements `transform` and `fit_transform`, but requires subclasses to implement `fit`.  This is because each specialized transformer will have estimator-specific keyword arguments and base forest types (e.g. `RandomForestClassifier` and `RandomForestRegressor`).  However, this class implements the method `_fit` which derived classes call with their specialized parameters and which sets the base estimator on each `y` target.
- Pulling the logic from `RFNodeTransformer` into `TreeNodeTransformer` for determining which base estimator to use for each `y` target as implemented in #91.
- Creating generic names to accommodate new transformers (e.g. `rfs_` to `estimators_` and `rf_type_dict_` to `estimator_type_dict_`)
- Rewriting tests to make clear the responsibility of both `TreeNodeTransformer` and `RFNodeTransformer`.