### PR TITLE
Remove invalid `undoc_members` config option

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -57,7 +57,6 @@ plugins:
           options:
             show_source: false
             inherited_members: true
-            undoc_members: true
             docstring_style: numpy
             show_if_no_docstring: true
             show_signature_annotations: true


### PR DESCRIPTION
Closes #102 by removing the invalid `undoc_members` configuration option.

`undoc_members` seems to be a Sphinx configuration option that was accidentally added. The parameter was previously being ignored, but now causes build errors locally and [in RTD](https://app.readthedocs.org/projects/sknnr/builds/30950283/).