### PR TITLE
Remove current directory as arg to pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ dependencies = [
 ]
 
 [tool.hatch.envs.test.scripts]
-all = "pytest . {args} --doctest-modules"
-coverage = "pytest . --cov=src/sknnr {args} --doctest-modules"
+all = "pytest {args} --doctest-modules"
+coverage = "pytest --cov=src/sknnr {args} --doctest-modules"
 
 [tool.hatch.envs.test_matrix]
 template = "test"


### PR DESCRIPTION
As of `pytest>9.0`, using `pytest . {args}` as the hatch script for `test:all` no longer allows specification of a subset of tests to run at command line.  For example:
```python
hatch run test:all ./tests/test_regressions.py
```
will run all tests in the test suite and not just the tests in `test_regressions.py`.  This PR simply removes the current directory (`.`) as a command-line argument to both `test:all` and `test:coverage` scripts which fixes the issue.

@aazuspan, in my limited searching, I couldn't find a specific issue/PR in `pytest` that noted this change.  I came across it when I updated the packages in my hatch `test` environment as part of some testing on #99.  I _think_ this is an OK fix, but let me know if there is a better way to get around this issue.