### PR TITLE
Upgrade minimum Python to 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -44,4 +44,4 @@ jobs:
           pip install hatch
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     runs-on: ubuntu-latest
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.15.5
     hooks:
-      - id: ruff
+      - id: ruff-check
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         exclude: ^tests/

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -12,7 +12,7 @@ pip install sknnr --pre
 
 ## Dependencies
 
-- Python >= 3.9
+- Python >= 3.11
 - scikit-learn >= 1.2
 - numpy
 - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sknnr"
 dynamic = ["version"]
 description = "Scikit-learn estimators for kNN regression methods"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 authors = [
     { name = "Matt Gregory", email = "matt.gregory@oregonstate.edu" },
     { name = "Aaron Zuspan", email = "aaron.zuspan@oregonstate.edu" },
@@ -48,7 +48,7 @@ coverage = "pytest --cov=src/sknnr {args} --doctest-modules"
 template = "test"
 
 [[tool.hatch.envs.test_matrix.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.envs.docs]
 dependencies = ["mkdocs", "mkdocs-material", "mkdocstrings[python]"]

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Callable, Literal
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin

--- a/src/sknnr/_gbnn.py
+++ b/src/sknnr/_gbnn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 from numpy.typing import ArrayLike
 from sklearn.base import BaseEstimator, TransformerMixin

--- a/src/sknnr/_rfnn.py
+++ b/src/sknnr/_rfnn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 from numpy.random import RandomState
 from numpy.typing import ArrayLike

--- a/src/sknnr/_weighted_trees.py
+++ b/src/sknnr/_weighted_trees.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -85,7 +86,9 @@ class WeightedTreesNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
         return np.hstack(
             [
                 tw * fw
-                for tw, fw in zip(self.transformer_.tree_weights_, forest_weights_arr)
+                for tw, fw in zip(
+                    self.transformer_.tree_weights_, forest_weights_arr, strict=True
+                )
             ]
         )
 

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import numpy as np
 from numpy.typing import NDArray
 from sklearn.preprocessing import StandardScaler
@@ -9,7 +7,7 @@ from .._base import _validate_data
 from ._cca import CCA
 from ._ccora import CCorA
 
-Ordination = Union[CCA, CCorA]
+Ordination = CCA | CCorA
 
 
 class StandardScalerWithDOF(StandardScaler):

--- a/src/sknnr/transformers/_gbnode_transformer.py
+++ b/src/sknnr/transformers/_gbnode_transformer.py
@@ -32,7 +32,7 @@ def train_improvement(
     # Calculate the initial loss, which by default in regression is based
     # on predicting the mean for all samples.  Use a multiplicative factor
     # following the same calculation as in scikit-learn
-    factor = 2 if isinstance(est._loss, (HalfSquaredError, HalfBinomialLoss)) else 1
+    factor = 2 if isinstance(est._loss, HalfSquaredError | HalfBinomialLoss) else 1
     initial_loss = (
         est._loss(np.asarray(y, dtype=np.float64), est._raw_predict_init(X)) * factor
     )
@@ -280,7 +280,7 @@ class GBNodeTransformer(TreeNodeTransformer):
     def _set_tree_weights(self, X, y) -> list[NDArray[np.float64]]:
         tree_weights = []
         if self.tree_weighting_method == "train_improvement":
-            for est, target in zip(self.estimators_, y):
+            for est, target in zip(self.estimators_, y, strict=True):
                 weights = train_improvement(est, X, target)
                 weights /= weights.sum()
                 tree_weights.append(np.tile(weights, est.n_trees_per_iteration_))

--- a/src/sknnr/transformers/_rfnode_transformer.py
+++ b/src/sknnr/transformers/_rfnode_transformer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 import numpy as np
 from numpy.random import RandomState

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -105,7 +105,7 @@ def get_feature_dtypes(obj) -> list[np.dtype | pd.CategoricalDtype]:
         promoted_dtypes = get_minimum_dtypes(obj)
         return [
             p_dtype if str(n_dtype) != "category" else n_dtype
-            for p_dtype, n_dtype in zip(promoted_dtypes, native_dtypes)
+            for p_dtype, n_dtype in zip(promoted_dtypes, native_dtypes, strict=True)
         ]
     if is_series_like(obj):
         native_dtype = obj.dtype
@@ -133,5 +133,7 @@ def get_feature_names_and_dtypes(
     """
     return {
         name: dtype
-        for name, dtype in zip(get_feature_names(obj), get_feature_dtypes(obj))
+        for name, dtype in zip(
+            get_feature_names(obj), get_feature_dtypes(obj), strict=True
+        )
     }

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -228,8 +228,8 @@ def test_estimators_warn_for_missing_features(estimator, fit_names):
         msg = "fitted without feature names"
         fit_X, predict_X = X, X_df
 
+    estimator.fit(fit_X, y)
     with pytest.warns(UserWarning, match=msg):
-        estimator.fit(fit_X, y)
         estimator.predict(predict_X)
 
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -373,7 +373,9 @@ def test_gbnode_transformer_multiclass(tree_weighting_method, n_classes):
     assert est.n_trees_per_iteration_ == [expected_n_classes, 1, 1]
     assert all(
         w.shape == (est.n_estimators * n_trees,)
-        for w, n_trees in zip(est.tree_weights_, est.n_trees_per_iteration_)
+        for w, n_trees in zip(
+            est.tree_weights_, est.n_trees_per_iteration_, strict=True
+        )
     )
 
     # Confirm the shape of the node matrix


### PR DESCRIPTION
This upgrades the minimum Python from 3.9 to 3.11 following the [NEP 29 schedule](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule), which also resolves a [Hatch bug in 3.9](https://github.com/lemma-osu/sklearn-raster/pull/109#issuecomment-3987828351). Local and Github Actions now test through 3.14. Pre-commit hook and action versions are bumped to the latest.

Aside from updating project and CI metadata, there were a few typing changes as well as the new `zip(..., strict=True)` parameter to satisfy static analysis.