### PR TITLE
Expand typing for the `datasets` module

### DIFF
--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -112,8 +112,8 @@ def load_dataset_from_csv_filenames(
     *,
     data_filename: str,
     target_filename: str,
-    return_X_y: Literal[False] = False,
-    as_frame: Literal[True] = True,
+    return_X_y: Literal[False],
+    as_frame: Literal[True],
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> Dataset[pd.DataFrame]: ...
 
@@ -124,7 +124,7 @@ def load_dataset_from_csv_filenames(
     data_filename: str,
     target_filename: str,
     return_X_y: Literal[True],
-    as_frame: Literal[False] = False,
+    as_frame: Literal[False],
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
 
@@ -229,13 +229,13 @@ def load_moscow_stjoes(
 
 @overload
 def load_moscow_stjoes(
-    return_X_y: Literal[False] = False, as_frame: Literal[True] = True
+    return_X_y: Literal[False], as_frame: Literal[True]
 ) -> Dataset[pd.DataFrame]: ...
 
 
 @overload
 def load_moscow_stjoes(
-    return_X_y: Literal[True], as_frame: Literal[False] = False
+    return_X_y: Literal[True], as_frame: Literal[False]
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
 
 
@@ -304,13 +304,13 @@ def load_swo_ecoplot(
 
 @overload
 def load_swo_ecoplot(
-    return_X_y: Literal[False] = False, as_frame: Literal[True] = True
+    return_X_y: Literal[False], as_frame: Literal[True]
 ) -> Dataset[pd.DataFrame]: ...
 
 
 @overload
 def load_swo_ecoplot(
-    return_X_y: Literal[True], as_frame: Literal[False] = False
+    return_X_y: Literal[True], as_frame: Literal[False]
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
 
 

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -4,7 +4,7 @@ import csv
 import types
 from dataclasses import dataclass
 from importlib import resources
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -92,6 +92,40 @@ def load_csv_data(
     return index, data, data_names
 
 
+@overload
+def load_dataset_from_csv_filenames(
+    *,
+    data_filename: str,
+    target_filename: str,
+    return_X_y: Literal[False] = False,
+    as_frame: bool = False,
+    module_name: str | types.ModuleType = DATA_MODULE,
+) -> Dataset: ...
+
+
+@overload
+def load_dataset_from_csv_filenames(
+    *,
+    data_filename: str,
+    target_filename: str,
+    return_X_y: Literal[True],
+    as_frame: Literal[False] = False,
+    module_name: str | types.ModuleType = DATA_MODULE,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
+
+
+@overload
+def load_dataset_from_csv_filenames(
+    *,
+    data_filename: str,
+    target_filename: str,
+    return_X_y: Literal[True],
+    as_frame: Literal[True],
+    module_name: str | types.ModuleType = DATA_MODULE,
+) -> tuple[pd.DataFrame, pd.DataFrame]: ...
+
+
+@overload
 def load_dataset_from_csv_filenames(
     *,
     data_filename: str,
@@ -99,7 +133,25 @@ def load_dataset_from_csv_filenames(
     return_X_y: bool = False,
     as_frame: bool = False,
     module_name: str | types.ModuleType = DATA_MODULE,
-) -> tuple[NDArray[np.float64], NDArray[np.float64]] | Dataset:
+) -> (
+    Dataset
+    | tuple[NDArray[np.float64], NDArray[np.float64]]
+    | tuple[pd.DataFrame, pd.DataFrame]
+): ...
+
+
+def load_dataset_from_csv_filenames(
+    *,
+    data_filename: str,
+    target_filename: str,
+    return_X_y: bool = False,
+    as_frame: bool = False,
+    module_name: str | types.ModuleType = DATA_MODULE,
+) -> (
+    Dataset
+    | tuple[NDArray[np.float64], NDArray[np.float64]]
+    | tuple[pd.DataFrame, pd.DataFrame]
+):
     """Load separate data and target CSV files into a dataset or paired NumPy arrays.
 
     Parameters
@@ -152,9 +204,31 @@ def load_dataset_from_csv_filenames(
     return (dataset.data, dataset.target) if return_X_y else dataset
 
 
+@overload
+def load_moscow_stjoes(
+    return_X_y: Literal[False] = False, as_frame: bool = False
+) -> Dataset: ...
+
+
+@overload
+def load_moscow_stjoes(
+    return_X_y: Literal[True], as_frame: Literal[False] = False
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
+
+
+@overload
+def load_moscow_stjoes(
+    return_X_y: Literal[True], as_frame: Literal[True]
+) -> tuple[pd.DataFrame, pd.DataFrame]: ...
+
+
 def load_moscow_stjoes(
     return_X_y: bool = False, as_frame: bool = False
-) -> tuple[NDArray[np.float64], NDArray[np.float64]] | Dataset:
+) -> (
+    Dataset
+    | tuple[NDArray[np.float64], NDArray[np.float64]]
+    | tuple[pd.DataFrame, pd.DataFrame]
+):
     """Load the Moscow Mountain / St. Joe's dataset (Hudak 2010[^1]).
 
     The dataset contains 165 plots with environmental, LiDAR, and forest structure
@@ -198,9 +272,31 @@ def load_moscow_stjoes(
     )
 
 
+@overload
+def load_swo_ecoplot(
+    return_X_y: Literal[False] = False, as_frame: bool = False
+) -> Dataset: ...
+
+
+@overload
+def load_swo_ecoplot(
+    return_X_y: Literal[True], as_frame: Literal[False] = False
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
+
+
+@overload
+def load_swo_ecoplot(
+    return_X_y: Literal[True], as_frame: Literal[True]
+) -> tuple[pd.DataFrame, pd.DataFrame]: ...
+
+
 def load_swo_ecoplot(
     return_X_y: bool = False, as_frame: bool = False
-) -> tuple[NDArray[np.float64], NDArray[np.float64]] | Dataset:
+) -> (
+    Dataset
+    | tuple[NDArray[np.float64], NDArray[np.float64]]
+    | tuple[pd.DataFrame, pd.DataFrame]
+):
     """Load the southwest Oregon (SWO) USFS Region 6 Ecoplot dataset.
 
     The dataset contains 3,005 plots with environmental, Landsat, and forest cover

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -149,7 +149,8 @@ def load_dataset_from_csv_filenames(
     as_frame: bool = False,
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> (
-    Dataset[T_ArrayOrFrame]
+    Dataset[NDArray[np.float64]]
+    | Dataset[pd.DataFrame]
     | tuple[NDArray[np.float64], NDArray[np.float64]]
     | tuple[pd.DataFrame, pd.DataFrame]
 ): ...
@@ -163,7 +164,8 @@ def load_dataset_from_csv_filenames(
     as_frame: bool = False,
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> (
-    Dataset[T_ArrayOrFrame]
+    Dataset[NDArray[np.float64]]
+    | Dataset[pd.DataFrame]
     | tuple[NDArray[np.float64], NDArray[np.float64]]
     | tuple[pd.DataFrame, pd.DataFrame]
 ):
@@ -204,7 +206,7 @@ def load_dataset_from_csv_filenames(
         file_name=target_filename, module_name=module_name
     )
 
-    dataset: Dataset[T_ArrayOrFrame] = Dataset(
+    dataset = Dataset(
         index=index,
         data=data,
         target=target,
@@ -246,7 +248,8 @@ def load_moscow_stjoes(
 def load_moscow_stjoes(
     return_X_y: bool = False, as_frame: bool = False
 ) -> (
-    Dataset[T_ArrayOrFrame]
+    Dataset[NDArray[np.float64]]
+    | Dataset[pd.DataFrame]
     | tuple[NDArray[np.float64], NDArray[np.float64]]
     | tuple[pd.DataFrame, pd.DataFrame]
 ):
@@ -320,7 +323,8 @@ def load_swo_ecoplot(
 def load_swo_ecoplot(
     return_X_y: bool = False, as_frame: bool = False
 ) -> (
-    Dataset[T_ArrayOrFrame]
+    Dataset[NDArray[np.float64]]
+    | Dataset[pd.DataFrame]
     | tuple[NDArray[np.float64], NDArray[np.float64]]
     | tuple[pd.DataFrame, pd.DataFrame]
 ):

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -60,7 +60,7 @@ def _dataset_as_frame(dataset: Dataset[NDArray[np.float64]]) -> Dataset[pd.DataF
 
 def load_csv_data(
     file_name: str, *, module_name: str | types.ModuleType = DATA_MODULE
-) -> tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.str_]]:
+) -> tuple[NDArray[np.int64], NDArray[np.float64], list[str]]:
     """Load data from a CSV file from the specified module_name.
 
     Parameters
@@ -76,7 +76,7 @@ def load_csv_data(
         The plot IDs from the first column of the CSV file.
     data: ndarray
         The data values from the remaining columns of the CSV file.
-    data_names: ndarray
+    data_names: list[str]
         The column names from the first row of the CSV file.
 
     Notes

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -4,7 +4,7 @@ import csv
 import types
 from dataclasses import dataclass
 from importlib import resources
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar, Union, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -14,12 +14,16 @@ if TYPE_CHECKING:
 
 DATA_MODULE = "sknnr.datasets.data"
 
+T_ArrayOrFrame = TypeVar(
+    "T_ArrayOrFrame", bound=Union[NDArray[np.float64], "pd.DataFrame"]
+)
+
 
 @dataclass
-class Dataset:
-    index: NDArray[np.int64] | pd.DataFrame
-    data: NDArray[np.float64] | pd.DataFrame
-    target: NDArray[np.float64] | pd.DataFrame
+class Dataset(Generic[T_ArrayOrFrame]):
+    index: NDArray[np.int64]
+    data: T_ArrayOrFrame
+    target: T_ArrayOrFrame
     frame: None | pd.DataFrame
     feature_names: list[str]
     target_names: list[str]
@@ -31,7 +35,7 @@ class Dataset:
         return f"Dataset(n={n}, features={n_features}, targets={n_targets})"
 
 
-def _dataset_as_frame(dataset: Dataset) -> Dataset:
+def _dataset_as_frame(dataset: Dataset[NDArray[np.float64]]) -> Dataset[pd.DataFrame]:
     """Convert a Dataset of arrays to a Dataset of DataFrames."""
     pd = _import_pandas()
 
@@ -98,9 +102,20 @@ def load_dataset_from_csv_filenames(
     data_filename: str,
     target_filename: str,
     return_X_y: Literal[False] = False,
-    as_frame: bool = False,
+    as_frame: Literal[False] = False,
     module_name: str | types.ModuleType = DATA_MODULE,
-) -> Dataset: ...
+) -> Dataset[NDArray[np.float64]]: ...
+
+
+@overload
+def load_dataset_from_csv_filenames(
+    *,
+    data_filename: str,
+    target_filename: str,
+    return_X_y: Literal[False] = False,
+    as_frame: Literal[True] = True,
+    module_name: str | types.ModuleType = DATA_MODULE,
+) -> Dataset[pd.DataFrame]: ...
 
 
 @overload
@@ -134,7 +149,7 @@ def load_dataset_from_csv_filenames(
     as_frame: bool = False,
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> (
-    Dataset
+    Dataset[T_ArrayOrFrame]
     | tuple[NDArray[np.float64], NDArray[np.float64]]
     | tuple[pd.DataFrame, pd.DataFrame]
 ): ...
@@ -148,7 +163,7 @@ def load_dataset_from_csv_filenames(
     as_frame: bool = False,
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> (
-    Dataset
+    Dataset[T_ArrayOrFrame]
     | tuple[NDArray[np.float64], NDArray[np.float64]]
     | tuple[pd.DataFrame, pd.DataFrame]
 ):
@@ -189,7 +204,7 @@ def load_dataset_from_csv_filenames(
         file_name=target_filename, module_name=module_name
     )
 
-    dataset = Dataset(
+    dataset: Dataset[T_ArrayOrFrame] = Dataset(
         index=index,
         data=data,
         target=target,
@@ -206,8 +221,14 @@ def load_dataset_from_csv_filenames(
 
 @overload
 def load_moscow_stjoes(
-    return_X_y: Literal[False] = False, as_frame: bool = False
-) -> Dataset: ...
+    return_X_y: Literal[False] = False, as_frame: Literal[False] = False
+) -> Dataset[NDArray[np.float64]]: ...
+
+
+@overload
+def load_moscow_stjoes(
+    return_X_y: Literal[False] = False, as_frame: Literal[True] = True
+) -> Dataset[pd.DataFrame]: ...
 
 
 @overload
@@ -225,7 +246,7 @@ def load_moscow_stjoes(
 def load_moscow_stjoes(
     return_X_y: bool = False, as_frame: bool = False
 ) -> (
-    Dataset
+    Dataset[T_ArrayOrFrame]
     | tuple[NDArray[np.float64], NDArray[np.float64]]
     | tuple[pd.DataFrame, pd.DataFrame]
 ):
@@ -274,8 +295,14 @@ def load_moscow_stjoes(
 
 @overload
 def load_swo_ecoplot(
-    return_X_y: Literal[False] = False, as_frame: bool = False
-) -> Dataset: ...
+    return_X_y: Literal[False] = False, as_frame: Literal[False] = False
+) -> Dataset[NDArray[np.float64]]: ...
+
+
+@overload
+def load_swo_ecoplot(
+    return_X_y: Literal[False] = False, as_frame: Literal[True] = True
+) -> Dataset[pd.DataFrame]: ...
 
 
 @overload
@@ -293,7 +320,7 @@ def load_swo_ecoplot(
 def load_swo_ecoplot(
     return_X_y: bool = False, as_frame: bool = False
 ) -> (
-    Dataset
+    Dataset[T_ArrayOrFrame]
     | tuple[NDArray[np.float64], NDArray[np.float64]]
     | tuple[pd.DataFrame, pd.DataFrame]
 ):

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -112,8 +112,8 @@ def load_dataset_from_csv_filenames(
     *,
     data_filename: str,
     target_filename: str,
-    return_X_y: Literal[False],
-    as_frame: Literal[True],
+    return_X_y: Literal[False] = ...,
+    as_frame: Literal[True] = ...,
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> Dataset[pd.DataFrame]: ...
 
@@ -123,8 +123,8 @@ def load_dataset_from_csv_filenames(
     *,
     data_filename: str,
     target_filename: str,
-    return_X_y: Literal[True],
-    as_frame: Literal[False],
+    return_X_y: Literal[True] = ...,
+    as_frame: Literal[False] = ...,
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
 
@@ -134,8 +134,8 @@ def load_dataset_from_csv_filenames(
     *,
     data_filename: str,
     target_filename: str,
-    return_X_y: Literal[True],
-    as_frame: Literal[True],
+    return_X_y: Literal[True] = ...,
+    as_frame: Literal[True] = ...,
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> tuple[pd.DataFrame, pd.DataFrame]: ...
 
@@ -145,8 +145,8 @@ def load_dataset_from_csv_filenames(
     *,
     data_filename: str,
     target_filename: str,
-    return_X_y: bool = False,
-    as_frame: bool = False,
+    return_X_y: bool = ...,
+    as_frame: bool = ...,
     module_name: str | types.ModuleType = DATA_MODULE,
 ) -> (
     Dataset[NDArray[np.float64]]
@@ -229,19 +229,19 @@ def load_moscow_stjoes(
 
 @overload
 def load_moscow_stjoes(
-    return_X_y: Literal[False], as_frame: Literal[True]
+    return_X_y: Literal[False] = ..., as_frame: Literal[True] = ...
 ) -> Dataset[pd.DataFrame]: ...
 
 
 @overload
 def load_moscow_stjoes(
-    return_X_y: Literal[True], as_frame: Literal[False]
+    return_X_y: Literal[True] = ..., as_frame: Literal[False] = ...
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
 
 
 @overload
 def load_moscow_stjoes(
-    return_X_y: Literal[True], as_frame: Literal[True]
+    return_X_y: Literal[True] = ..., as_frame: Literal[True] = ...
 ) -> tuple[pd.DataFrame, pd.DataFrame]: ...
 
 
@@ -304,19 +304,19 @@ def load_swo_ecoplot(
 
 @overload
 def load_swo_ecoplot(
-    return_X_y: Literal[False], as_frame: Literal[True]
+    return_X_y: Literal[False] = ..., as_frame: Literal[True] = ...
 ) -> Dataset[pd.DataFrame]: ...
 
 
 @overload
 def load_swo_ecoplot(
-    return_X_y: Literal[True], as_frame: Literal[False]
+    return_X_y: Literal[True] = ..., as_frame: Literal[False] = ...
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]: ...
 
 
 @overload
 def load_swo_ecoplot(
-    return_X_y: Literal[True], as_frame: Literal[True]
+    return_X_y: Literal[True] = ..., as_frame: Literal[True] = ...
 ) -> tuple[pd.DataFrame, pd.DataFrame]: ...
 
 


### PR DESCRIPTION
This is an incremental step towards #7 that expands typing in the `datasets` module by:

1. Adding overloads that clarify the return types for the dataset loading functions, and
2. Making `Dataset` a generic type around arrays or dataframes.

To demonstrate the improvement, here are the revealed types on this branch (note that `array_data` *is* correctly inferred as `NDArray[float64]` when you hover, but VS Code isn't displaying it here for some reason):

<img width="776" height="223" alt="image" src="https://github.com/user-attachments/assets/e1c101df-eb1e-49db-94bb-892a9c12a2e3" />

Compared to `main` (types are being truncated, but are all unions):

<img width="918" height="224" alt="image" src="https://github.com/user-attachments/assets/b9d577dc-3334-454a-adff-2758f8946937" />