### PR TITLE
Expand typing for the `utils` module

### DIFF
--- a/src/sknnr/types.py
+++ b/src/sknnr/types.py
@@ -1,10 +1,14 @@
-from collections.abc import Sequence
-from typing import Protocol, TypeAlias
+from __future__ import annotations
 
-from numpy.typing import DTypeLike as NDTypeLike
-from pandas.api.extensions import ExtensionDtype
+from typing import TYPE_CHECKING, Protocol, Union
 
-DTypeLike: TypeAlias = NDTypeLike | ExtensionDtype
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from numpy.typing import DTypeLike as NDTypeLike
+    from pandas.api.extensions import ExtensionDtype
+
+DTypeLike = Union["NDTypeLike", "ExtensionDtype"]
 
 
 class DataFrameLike(Protocol):

--- a/src/sknnr/types.py
+++ b/src/sknnr/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol, Union
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Hashable, Sequence
 
     from numpy.typing import DTypeLike as NDTypeLike
     from pandas.api.extensions import ExtensionDtype
@@ -14,12 +14,12 @@ DTypeLike = Union["NDTypeLike", "ExtensionDtype"]
 class DataFrameLike(Protocol):
     """A protocol for dataframe-like objects, such as pandas and polars DataFrames."""
 
-    columns: Sequence[str]
+    columns: Sequence[Hashable]
     dtypes: Sequence[DTypeLike]
 
 
 class SeriesLike(Protocol):
     """A protocol for series-like objects, such as pandas and polars Series."""
 
-    name: str | None
+    name: Hashable | None
     dtype: DTypeLike

--- a/src/sknnr/types.py
+++ b/src/sknnr/types.py
@@ -1,0 +1,21 @@
+from collections.abc import Sequence
+from typing import Protocol, TypeAlias
+
+from numpy.typing import DTypeLike as NDTypeLike
+from pandas.api.extensions import ExtensionDtype
+
+DTypeLike: TypeAlias = NDTypeLike | ExtensionDtype
+
+
+class DataFrameLike(Protocol):
+    """A protocol for dataframe-like objects, such as pandas and polars DataFrames."""
+
+    columns: Sequence[str]
+    dtypes: Sequence[DTypeLike]
+
+
+class SeriesLike(Protocol):
+    """A protocol for series-like objects, such as pandas and polars Series."""
+
+    name: str
+    dtype: DTypeLike

--- a/src/sknnr/types.py
+++ b/src/sknnr/types.py
@@ -21,5 +21,5 @@ class DataFrameLike(Protocol):
 class SeriesLike(Protocol):
     """A protocol for series-like objects, such as pandas and polars Series."""
 
-    name: str
+    name: str | None
     dtype: DTypeLike

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable, Sequence
     from typing import TypeGuard
 
     import pandas as pd
@@ -56,7 +56,9 @@ def is_nan_like(x: object) -> bool:
     )
 
 
-def get_feature_names(obj: None | Sequence | DataFrameLike | SeriesLike) -> list[str]:
+def get_feature_names(
+    obj: None | Sequence | DataFrameLike | SeriesLike,
+) -> list[Hashable]:
     """
     Get the names of the features in `obj`. If no names are found, return
     a list of strings with the feature index.
@@ -123,7 +125,7 @@ def get_feature_dtypes(
 
 def get_feature_names_and_dtypes(
     obj: None | Sequence | DataFrameLike | SeriesLike,
-) -> dict[str, np.dtype | pd.CategoricalDtype]:
+) -> dict[Hashable, np.dtype | pd.CategoricalDtype]:
     """
     Get the names and dtypes of the features in `obj` and return as dict.
 
@@ -134,7 +136,7 @@ def get_feature_names_and_dtypes(
 
     Returns:
     --------
-    dict[str, np.dtype | pd.CategoricalDtype] : dict
+    dict[Hashable, np.dtype | pd.CategoricalDtype] : dict
         The feature names and dtypes of the features in `obj`.
     """
     return {

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -8,8 +8,6 @@ if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
     from typing import TypeGuard
 
-    import pandas as pd
-
     from ..types import DataFrameLike, DTypeLike, SeriesLike
 
 
@@ -75,7 +73,7 @@ def get_feature_names(
     return [str(i) for i in range(arr.shape[1])]
 
 
-def get_minimum_dtypes(obj: Sequence | DataFrameLike | SeriesLike) -> list[np.dtype]:
+def get_minimum_dtypes(obj: Sequence | DataFrameLike | SeriesLike) -> list[DTypeLike]:
     """
     Return the smallest numpy dtype that can accommodate all data for each
     column in obj.
@@ -88,7 +86,7 @@ def get_minimum_dtypes(obj: Sequence | DataFrameLike | SeriesLike) -> list[np.dt
 
 def get_feature_dtypes(
     obj: None | Sequence | DataFrameLike | SeriesLike,
-) -> list[np.dtype | pd.CategoricalDtype]:
+) -> list[DTypeLike]:
     """
     Get numpy dtypes of the features in `obj`, promoting dtypes as necessary to
     the smallest type that can accommodate all data elements in that feature.
@@ -102,7 +100,7 @@ def get_feature_dtypes(
 
     Returns:
     --------
-    list of dtypes : list[np.dtype | pd.CategoricalDtype]
+    list of dtypes : list[DTypeLike]
         The dtypes (either numpy or pd.CategoricalDtype) of the features in `obj`.
     """
     if obj is None or len(np.asarray(obj)) == 0:
@@ -125,7 +123,7 @@ def get_feature_dtypes(
 
 def get_feature_names_and_dtypes(
     obj: None | Sequence | DataFrameLike | SeriesLike,
-) -> dict[Hashable, np.dtype | pd.CategoricalDtype]:
+) -> dict[Hashable, DTypeLike]:
     """
     Get the names and dtypes of the features in `obj` and return as dict.
 
@@ -136,7 +134,7 @@ def get_feature_names_and_dtypes(
 
     Returns:
     --------
-    dict[Hashable, np.dtype | pd.CategoricalDtype] : dict
+    dict[Hashable, DTypeLike] : dict
         The feature names and dtypes of the features in `obj`.
     """
     return {

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from typing import TypeGuard
+
     import pandas as pd
 
+    from ..types import DataFrameLike, DTypeLike, SeriesLike
 
-def is_dataframe_like(obj: Any) -> bool:
+
+def is_dataframe_like(obj: object) -> TypeGuard[DataFrameLike]:
     """
     Check if `obj` is a dataframe-like structure.  This will evaluate to `True`
     for pandas and polars DataFrames without the need to import those packages
@@ -18,7 +22,7 @@ def is_dataframe_like(obj: Any) -> bool:
     return hasattr(obj, "columns") and hasattr(obj, "dtypes")
 
 
-def is_series_like(obj: Any) -> bool:
+def is_series_like(obj: object) -> TypeGuard[SeriesLike]:
     """
     Check if `obj` is a series-like structure.  This will evaluate to `True`
     for pandas and polars Series without the need to import those packages
@@ -27,7 +31,7 @@ def is_series_like(obj: Any) -> bool:
     return hasattr(obj, "name") and hasattr(obj, "dtype")
 
 
-def is_number_like_type(t: Any) -> bool:
+def is_number_like_type(t: DTypeLike) -> bool:
     """
     Check if `t` is a number-like type.  For most types, np.issubdtype will
     correctly identify the type.  For pandas extension types, we can check the
@@ -43,7 +47,7 @@ def is_number_like_type(t: Any) -> bool:
             raise TypeError(msg) from err
 
 
-def is_nan_like(x: Any) -> bool:
+def is_nan_like(x: object) -> bool:
     """Check if `x` is NaN-like, including None, np.nan, and pd.NA values."""
     return bool(
         x is None
@@ -52,7 +56,7 @@ def is_nan_like(x: Any) -> bool:
     )
 
 
-def get_feature_names(obj) -> list[str]:
+def get_feature_names(obj: None | Sequence | DataFrameLike | SeriesLike) -> list[str]:
     """
     Get the names of the features in `obj`. If no names are found, return
     a list of strings with the feature index.
@@ -63,24 +67,26 @@ def get_feature_names(obj) -> list[str]:
         return list(obj.columns)
     if is_series_like(obj):
         return ["0"] if obj.name is None else [obj.name]
-    obj = np.asarray(obj, dtype=object)
-    if obj.ndim == 1:
-        obj = obj.reshape(-1, 1)
-    return [str(i) for i in range(obj.shape[1])]
+    arr = np.asarray(obj, dtype=object)
+    if arr.ndim == 1:
+        arr = arr.reshape(-1, 1)
+    return [str(i) for i in range(arr.shape[1])]
 
 
-def get_minimum_dtypes(obj: Any) -> list[np.dtype]:
+def get_minimum_dtypes(obj: Sequence | DataFrameLike | SeriesLike) -> list[np.dtype]:
     """
     Return the smallest numpy dtype that can accommodate all data for each
     column in obj.
     """
-    obj = np.asarray(obj, dtype=object)
-    if obj.ndim == 1:
-        obj = obj.reshape(-1, 1)
-    return [np.asarray(obj[:, i].tolist()).dtype for i in range(obj.shape[1])]
+    arr = np.asarray(obj, dtype=object)
+    if arr.ndim == 1:
+        arr = arr.reshape(-1, 1)
+    return [np.asarray(arr[:, i].tolist()).dtype for i in range(arr.shape[1])]
 
 
-def get_feature_dtypes(obj) -> list[np.dtype | pd.CategoricalDtype]:
+def get_feature_dtypes(
+    obj: None | Sequence | DataFrameLike | SeriesLike,
+) -> list[np.dtype | pd.CategoricalDtype]:
     """
     Get numpy dtypes of the features in `obj`, promoting dtypes as necessary to
     the smallest type that can accommodate all data elements in that feature.
@@ -116,7 +122,7 @@ def get_feature_dtypes(obj) -> list[np.dtype | pd.CategoricalDtype]:
 
 
 def get_feature_names_and_dtypes(
-    obj: Sequence,
+    obj: None | Sequence | DataFrameLike | SeriesLike,
 ) -> dict[str, np.dtype | pd.CategoricalDtype]:
     """
     Get the names and dtypes of the features in `obj` and return as dict.

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -93,7 +93,7 @@ def get_feature_dtypes(
 
     Parameters
     ----------
-    obj : array-like, DataFrame, or Series
+    obj : array-like, DataFrame, or Series, optional
         The object from which to get the feature dtypes.
 
     Returns:
@@ -127,7 +127,7 @@ def get_feature_names_and_dtypes(
 
     Parameters
     ----------
-    obj : array-like, DataFrame, or Series
+    obj : array-like, DataFrame, or Series, optional
         The object to get the feature names and dtypes from.
 
     Returns:

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -36,13 +36,11 @@ def is_number_like_type(t: DTypeLike) -> bool:
     kind of the type.
     """
     try:
-        return np.issubdtype(t, np.number)
-    except TypeError:
-        try:
-            return t.kind in "iuf"
-        except AttributeError as err:
-            msg = f"Unsupported type {t}"
-            raise TypeError(msg) from err
+        return np.issubdtype(t, np.number)  # type: ignore[arg-type]
+    except TypeError as e:
+        if kind := getattr(t, "kind", None):
+            return kind in "iuf"
+        raise TypeError(f"Unsupported type {t}") from e
 
 
 def is_nan_like(x: object) -> bool:


### PR DESCRIPTION
This is an incremental step towards https://github.com/lemma-osu/sknnr/issues/7 that expands typing in the `utils` module by:

1. Replacing `Any` with `object` (see the [Mypy docs](https://mypy.readthedocs.io/en/stable/dynamic_typing.html#any-vs-object) for how those differ) or more specific types to enforce type checks, and
2. Adding a `types` submodule with commonly used protocols.

Unlike #109, there aren't any immediate benefits in terms of type inference for users, so this is mostly about improving static type checking.

Note that in a few places I renamed `obj` to `arr` to avoid reassigning an incompatible type. This could also be handled with a `cast`.