### PR TITLE
Expand typing for estimators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ select = [
     "RET",
     "SIM",
     "PERF",
+    "TC",
 ]
 
 [tool.ruff.lint.isort]

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.metrics import DistanceMetric
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.utils.validation import _is_arraylike, check_is_fitted
 
 from sknnr.utils import is_dataframe_like, is_series_like
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Literal, Self
 
     from numpy.typing import NDArray
+    from sklearn.metrics import DistanceMetric
     from sklearn.utils._tags import Tags
 
     from .transformers._base import ComponentReducerMixin

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -174,7 +174,7 @@ class RawKNNRegressor(
         return_distance: bool = True,
         return_dataframe_index: bool = False,
         use_deterministic_ordering: bool = True,
-    ) -> NDArray | tuple[NDArray, NDArray]:
+    ) -> NDArray[np.int64] | tuple[NDArray[np.float64], NDArray[np.int64]]:
         """
         Find the K-neighbors of a point or points in the dataset and optionally
         return dataframe indexes rather than array indices when the model was

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -11,10 +11,19 @@ from sklearn.neighbors import KNeighborsRegressor
 from sklearn.utils.validation import _is_arraylike, check_is_fitted
 
 if TYPE_CHECKING:
+    from typing import Literal
+
+    from numpy.typing import NDArray
+
     from .transformers._base import ComponentReducerMixin
 
 
-def _validate_data(estimator, *, ensure_all_finite: bool = True, **kwargs):
+def _validate_data(
+    estimator: BaseEstimator,
+    *,
+    ensure_all_finite: bool | Literal["allow-nan"] = True,
+    **kwargs,
+) -> NDArray | tuple[NDArray, NDArray]:
     """
     Compatibility wrapper around sklearn's _validate_data function.
 

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -20,9 +20,40 @@ if TYPE_CHECKING:
     from .types import DataLike
 
 
+@overload
 def _validate_data(
     estimator: BaseEstimator,
     *,
+    X: DataLike,
+    y: Literal["no-validation"] = "no-validation",
+    ensure_all_finite: bool | Literal["allow-nan"] = True,
+    **kwargs,
+) -> NDArray: ...
+@overload
+def _validate_data(
+    estimator: BaseEstimator,
+    *,
+    X: Literal["no-validation"] = "no-validation",
+    y: DataLike,
+    ensure_all_finite: bool | Literal["allow-nan"] = True,
+    **kwargs,
+) -> NDArray: ...
+@overload
+def _validate_data(
+    estimator: BaseEstimator,
+    *,
+    X: DataLike,
+    y: DataLike,
+    ensure_all_finite: bool | Literal["allow-nan"] = True,
+    **kwargs,
+) -> tuple[NDArray, NDArray]: ...
+
+
+def _validate_data(
+    estimator: BaseEstimator,
+    *,
+    X: DataLike | Literal["no-validation"] = "no-validation",
+    y: DataLike | Literal["no-validation"] | None = "no-validation",
     ensure_all_finite: bool | Literal["allow-nan"] = True,
     **kwargs,
 ) -> NDArray | tuple[NDArray, NDArray]:
@@ -39,9 +70,13 @@ def _validate_data(
     try:
         from sklearn.utils.validation import validate_data
     except ImportError:
-        return estimator._validate_data(force_all_finite=ensure_all_finite, **kwargs)
+        return estimator._validate_data(
+            X=X, y=y, force_all_finite=ensure_all_finite, **kwargs
+        )
 
-    return validate_data(estimator, ensure_all_finite=ensure_all_finite, **kwargs)
+    return validate_data(
+        estimator, X=X, y=y, ensure_all_finite=ensure_all_finite, **kwargs
+    )
 
 
 class DFIndexCrosswalkMixin:

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -348,7 +348,7 @@ class TransformedKNeighborsRegressor(BaseEstimator, ABC):
         return_distance: bool = True,
         return_dataframe_index: bool = False,
         use_deterministic_ordering: bool = True,
-    ) -> NDArray | tuple[NDArray, NDArray]:
+    ) -> NDArray[np.int64] | tuple[NDArray[np.float64], NDArray[np.int64]]:
         """
         Find the K-neighbors of a point or points of transformed feature data
         and optionally return dataframe indexes rather than array indices when
@@ -402,7 +402,7 @@ class TransformedKNeighborsRegressor(BaseEstimator, ABC):
             use_deterministic_ordering=use_deterministic_ordering,
         )
 
-    def predict(self, X: DataLike) -> NDArray:
+    def predict(self, X: DataLike) -> NDArray[np.float64]:
         X_transformed = self._transform_X(X)
         return self.regressor_.predict(X_transformed)
 

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -8,8 +8,6 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.utils.validation import _is_arraylike, check_is_fitted
 
-from sknnr.utils import is_dataframe_like, is_series_like
-
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Literal, Self
@@ -51,10 +49,9 @@ class DFIndexCrosswalkMixin:
 
     def _set_dataframe_index_in(self, X: DataLike) -> None:
         """Store dataframe indexes if X is a dataframe."""
-        if is_dataframe_like(X) or is_series_like(X):
-            index = X.index
-            if _is_arraylike(index):
-                self.dataframe_index_in_ = np.asarray(index)
+        index = getattr(X, "index", None)
+        if _is_arraylike(index):
+            self.dataframe_index_in_ = np.asarray(index)
 
 
 class IndependentPredictorMixin(KNeighborsRegressor):

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -374,7 +374,7 @@ class TransformedKNeighborsRegressor(BaseEstimator, ABC):
         X_transformed = self._transform_X(X)
         return self.regressor_.predict(X_transformed)
 
-    def score(self, X: DataLike, y: DataLike | None = None) -> float:
+    def score(self, X: DataLike, y: DataLike) -> float:
         X_transformed = self._transform_X(X)
         return self.regressor_.score(X_transformed, y)
 

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -10,12 +10,16 @@ from sklearn.metrics import DistanceMetric
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.utils.validation import _is_arraylike, check_is_fitted
 
+from sknnr.utils import is_dataframe_like, is_series_like
+
 if TYPE_CHECKING:
-    from typing import Literal
+    from typing import Literal, Self
 
     from numpy.typing import NDArray
+    from sklearn.utils._tags import Tags
 
     from .transformers._base import ComponentReducerMixin
+    from .types import DataLike
 
 
 def _validate_data(
@@ -45,37 +49,22 @@ def _validate_data(
 class DFIndexCrosswalkMixin:
     """Mixin to crosswalk array indices to dataframe indexes."""
 
-    def _set_dataframe_index_in(self, X):
+    def _set_dataframe_index_in(self, X: DataLike) -> None:
         """Store dataframe indexes if X is a dataframe."""
-        index = getattr(X, "index", None)
-        if _is_arraylike(index):
-            self.dataframe_index_in_ = np.asarray(index)
+        if is_dataframe_like(X) or is_series_like(X):
+            index = X.index
+            if _is_arraylike(index):
+                self.dataframe_index_in_ = np.asarray(index)
 
 
-class IndependentPredictorMixin:
+class IndependentPredictorMixin(KNeighborsRegressor):
     """Mixin to return independent predictions based on the X data used
     for fitting the model."""
 
-    def _set_independent_prediction_attributes(self, y):
+    def _set_independent_prediction_attributes(self, y: DataLike) -> None:
         """Store independent predictions and score."""
         self.independent_prediction_ = super().predict(X=None)
         self.independent_score_ = super().score(X=None, y=y)
-
-
-class YFitMixin:
-    """Mixin for transformed estimators that use an optional y_fit to fit their
-    transformer."""
-
-    def _set_fitted_transformer(self, X, y):
-        """Fit and store the transformer, using stored y_fit data if available."""
-        y_fit = self.y_fit_ if self.y_fit_ is not None else y
-        self.transformer_ = self._get_transformer().fit(X, y_fit)
-
-    def fit(self, X, y, y_fit=None):
-        """Fit using transformed feature data. If y_fit is provided, it will be used
-        to fit the transformer."""
-        self.y_fit_ = y_fit
-        return super().fit(X, y)
 
 
 class RawKNNRegressor(
@@ -139,7 +128,7 @@ class RawKNNRegressor(
 
     DISTANCE_PRECISION_DECIMALS = 10
 
-    def fit(self, X, y):
+    def fit(self, X: DataLike, y: DataLike) -> Self:
         """Override fit to set attributes using mixins."""
         self._set_dataframe_index_in(X)
         self = super().fit(X, y)
@@ -148,12 +137,12 @@ class RawKNNRegressor(
 
     def kneighbors(
         self,
-        X=None,
-        n_neighbors=None,
-        return_distance=True,
-        return_dataframe_index=False,
-        use_deterministic_ordering=True,
-    ):
+        X: DataLike | None = None,
+        n_neighbors: int | None = None,
+        return_distance: bool = True,
+        return_dataframe_index: bool = False,
+        use_deterministic_ordering: bool = True,
+    ) -> NDArray | tuple[NDArray, NDArray]:
         """
         Find the K-neighbors of a point or points in the dataset and optionally
         return dataframe indexes rather than array indices when the model was
@@ -261,22 +250,22 @@ class TransformedKNeighborsRegressor(BaseEstimator, ABC):
         subclasses."""
         ...
 
-    def _set_fitted_transformer(self, X, y):
+    def _set_fitted_transformer(self, X: DataLike, y: DataLike) -> None:
         """Fit and store the transformer."""
         self.transformer_ = self._get_transformer().fit(X, y)
 
-    def _get_additional_regressor_init_kwargs(self) -> dict:
+    def _get_additional_regressor_init_kwargs(self) -> dict[str, object]:
         """Get any additional keyword arguments for the KNeighbors regressor
         initialization. Subclasses can override to provide additional arguments.
         """
         return {}
 
-    def _transform_X(self, X):
+    def _transform_X(self, X: DataLike | None) -> DataLike | None:
         """Transform feature data using the fitted transformer."""
         check_is_fitted(self, "transformer_")
         return self.transformer_.transform(X) if X is not None else X
 
-    def fit(self, X, y):
+    def fit(self, X: DataLike, y: DataLike) -> Self:
         """Fit using transformed feature data."""
         _validate_data(self, X=X, y=y, ensure_all_finite=True, multi_output=True)
 
@@ -322,12 +311,12 @@ class TransformedKNeighborsRegressor(BaseEstimator, ABC):
 
     def kneighbors(
         self,
-        X=None,
-        n_neighbors=None,
-        return_distance=True,
-        return_dataframe_index=False,
-        use_deterministic_ordering=True,
-    ):
+        X: DataLike | None = None,
+        n_neighbors: int | None = None,
+        return_distance: bool = True,
+        return_dataframe_index: bool = False,
+        use_deterministic_ordering: bool = True,
+    ) -> NDArray | tuple[NDArray, NDArray]:
         """
         Find the K-neighbors of a point or points of transformed feature data
         and optionally return dataframe indexes rather than array indices when
@@ -381,19 +370,35 @@ class TransformedKNeighborsRegressor(BaseEstimator, ABC):
             use_deterministic_ordering=use_deterministic_ordering,
         )
 
-    def predict(self, X):
+    def predict(self, X: DataLike) -> NDArray:
         X_transformed = self._transform_X(X)
         return self.regressor_.predict(X_transformed)
 
-    def score(self, X, y=None):
+    def score(self, X: DataLike, y: DataLike | None = None) -> float:
         X_transformed = self._transform_X(X)
         return self.regressor_.score(X_transformed, y)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.sparse = False
 
         return tags
+
+
+class YFitMixin(TransformedKNeighborsRegressor):
+    """Mixin for transformed estimators that use an optional y_fit to fit their
+    transformer."""
+
+    def _set_fitted_transformer(self, X: DataLike, y: DataLike) -> None:
+        """Fit and store the transformer, using stored y_fit data if available."""
+        y_fit = self.y_fit_ if self.y_fit_ is not None else y
+        self.transformer_ = self._get_transformer().fit(X, y_fit)
+
+    def fit(self, X: DataLike, y: DataLike, y_fit: DataLike | None = None) -> Self:
+        """Fit using transformed feature data. If y_fit is provided, it will be used
+        to fit the transformer."""
+        self.y_fit_ = y_fit
+        return super().fit(X, y)
 
 
 class OrdinationKNeighborsRegressor(TransformedKNeighborsRegressor, ABC):

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -25,7 +25,7 @@ def _validate_data(
     estimator: BaseEstimator,
     *,
     X: DataLike,
-    y: Literal["no-validation"] = "no-validation",
+    y: Literal["no_validation"] = "no_validation",
     ensure_all_finite: bool | Literal["allow-nan"] = True,
     **kwargs,
 ) -> NDArray: ...
@@ -33,7 +33,7 @@ def _validate_data(
 def _validate_data(
     estimator: BaseEstimator,
     *,
-    X: Literal["no-validation"] = "no-validation",
+    X: Literal["no_validation"] = "no_validation",
     y: DataLike,
     ensure_all_finite: bool | Literal["allow-nan"] = True,
     **kwargs,
@@ -52,8 +52,8 @@ def _validate_data(
 def _validate_data(
     estimator: BaseEstimator,
     *,
-    X: DataLike | Literal["no-validation"] = "no-validation",
-    y: DataLike | Literal["no-validation"] | None = "no-validation",
+    X: DataLike | Literal["no_validation"] = "no_validation",
+    y: DataLike | Literal["no_validation"] | None = "no_validation",
     ensure_all_finite: bool | Literal["allow-nan"] = True,
     **kwargs,
 ) -> NDArray | tuple[NDArray, NDArray]:

--- a/src/sknnr/_gbnn.py
+++ b/src/sknnr/_gbnn.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Literal
-
-from numpy.typing import ArrayLike
-from sklearn.base import BaseEstimator, TransformerMixin
+from typing import TYPE_CHECKING, Literal
 
 from ._weighted_trees import WeightedTreesNNRegressor
 from .transformers import GBNodeTransformer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import ArrayLike
+    from sklearn.base import BaseEstimator, TransformerMixin
 
 
 class GBNNRegressor(WeightedTreesNNRegressor):

--- a/src/sknnr/_rfnn.py
+++ b/src/sknnr/_rfnn.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Literal
-
-from numpy.random import RandomState
-from numpy.typing import ArrayLike
-from sklearn.base import TransformerMixin
+from typing import TYPE_CHECKING, Literal
 
 from ._weighted_trees import WeightedTreesNNRegressor
 from .transformers import RFNodeTransformer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.random import RandomState
+    from numpy.typing import ArrayLike
+    from sklearn.base import TransformerMixin
 
 
 class RFNNRegressor(WeightedTreesNNRegressor):

--- a/src/sknnr/_weighted_trees.py
+++ b/src/sknnr/_weighted_trees.py
@@ -9,9 +9,10 @@ from ._base import TransformedKNeighborsRegressor, YFitMixin
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from numpy.typing import ArrayLike
+    from numpy.typing import ArrayLike, NDArray
 
     from .transformers._tree_node_transformer import TreeNodeTransformer
+    from .types import DataLike
 
 
 class WeightedTreesNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
@@ -57,11 +58,11 @@ class WeightedTreesNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
             n_jobs=n_jobs,
         )
 
-    def _set_fitted_transformer(self, X, y) -> None:
+    def _set_fitted_transformer(self, X: DataLike, y: DataLike) -> None:
         super()._set_fitted_transformer(X, y)
         self.hamming_weights_ = self._get_hamming_weights()
 
-    def _get_hamming_weights(self):
+    def _get_hamming_weights(self) -> NDArray[np.float64]:
         """
         Get the weights for the Hamming distance metric, based on tree weights
         from the transformer and forest weights provided as a user parameter.
@@ -96,7 +97,7 @@ class WeightedTreesNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
             ]
         )
 
-    def _validate_user_forest_weights(self):
+    def _validate_user_forest_weights(self) -> NDArray[np.float64]:
         """
         Validate user-supplied forest weights, ensuring they are numeric,
         finite and non-negative.
@@ -135,5 +136,5 @@ class WeightedTreesNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
             )
         return forest_weights
 
-    def _get_additional_regressor_init_kwargs(self) -> dict:
+    def _get_additional_regressor_init_kwargs(self) -> dict[str, object]:
         return {"metric_params": {"w": self.hamming_weights_}}

--- a/src/sknnr/_weighted_trees.py
+++ b/src/sknnr/_weighted_trees.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ._base import TransformedKNeighborsRegressor, YFitMixin
-from .transformers._tree_node_transformer import TreeNodeTransformer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import ArrayLike
+
+    from .transformers._tree_node_transformer import TreeNodeTransformer
 
 
 class WeightedTreesNNRegressor(YFitMixin, TransformedKNeighborsRegressor):

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import csv
-import types
 from dataclasses import dataclass
 from importlib import resources
 from typing import TYPE_CHECKING, Generic, Literal, TypeVar, Union, overload
@@ -10,6 +9,8 @@ import numpy as np
 from numpy.typing import NDArray
 
 if TYPE_CHECKING:
+    import types
+
     import pandas as pd
 
 DATA_MODULE = "sknnr.datasets.data"

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 import numpy as np
 from numpy.typing import NDArray
 from sklearn.preprocessing import StandardScaler
@@ -37,11 +39,11 @@ class StandardScalerWithDOF(StandardScaler):
         The number of samples processed by the estimator for each feature.
     """
 
-    def __init__(self, ddof=0):
+    def __init__(self, ddof: int = 0):
         super().__init__()
         self.ddof = ddof
 
-    def fit(self, X, y=None):
+    def fit(self, X, y: None = None) -> Self:
         scaler = super().fit(X, y)
 
         X = _validate_data(
@@ -64,7 +66,7 @@ class ComponentReducerMixin:
 
     ordination_: Ordination
 
-    def __init__(self, n_components=None):
+    def __init__(self, n_components: int | None = None):
         self.n_components = n_components
 
     def get_feature_names_out(self) -> NDArray:
@@ -77,7 +79,7 @@ class ComponentReducerMixin:
             dtype=object,
         )
 
-    def set_n_components(self):
+    def set_n_components(self) -> None:
         n_components = (
             self.n_components
             if self.n_components is not None

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -78,7 +78,7 @@ class ComponentReducerMixin:
     def __init__(self, n_components: int | None = None):
         self.n_components = n_components
 
-    def get_feature_names_out(self) -> NDArray:
+    def get_feature_names_out(self) -> NDArray[np.object_]:
         check_is_fitted(self, "n_components_")
         return np.asarray(
             [

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -55,7 +55,7 @@ class StandardScalerWithDOF(StandardScaler):
     def fit(self, X: DataLike, y: DataLike | None = None) -> Self:
         scaler = super().fit(X, y)
 
-        X = _validate_data(
+        X_arr = _validate_data(
             self,
             X=X,
             accept_sparse=False,
@@ -64,7 +64,7 @@ class StandardScalerWithDOF(StandardScaler):
             reset=False,
             ensure_min_samples=self.ddof + 1,
         )
-        scaler.scale_ = np.std(X, axis=0, ddof=self.ddof)
+        scaler.scale_ = np.std(X_arr, axis=0, ddof=self.ddof)
         return scaler
 
 

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -1,7 +1,8 @@
-from typing import Self
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import NDArray
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 
@@ -10,6 +11,14 @@ from ._cca import CCA
 from ._ccora import CCorA
 
 Ordination = CCA | CCorA
+
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from numpy.typing import NDArray
+
+    from ..types import DataLike
 
 
 class StandardScalerWithDOF(StandardScaler):
@@ -43,7 +52,7 @@ class StandardScalerWithDOF(StandardScaler):
         super().__init__()
         self.ddof = ddof
 
-    def fit(self, X, y: None = None) -> Self:
+    def fit(self, X: DataLike, y: DataLike | None = None) -> Self:
         scaler = super().fit(X, y)
 
         X = _validate_data(

--- a/src/sknnr/transformers/_cca.py
+++ b/src/sknnr/transformers/_cca.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import math
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 def zero_sum_rows(arr: NDArray) -> NDArray:

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
@@ -5,6 +9,14 @@ from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
 from .._base import _validate_data
 from . import ComponentReducerMixin
 from ._cca import CCA
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from numpy.typing import NDArray
+    from sklearn.utils._tags import Tags
+
+    from ..types import DataLike
 
 
 class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
@@ -42,7 +54,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     67: 1167–1179.
     """
 
-    def fit(self, X, y):
+    def fit(self, X: DataLike, y: DataLike) -> Self:
         X = _validate_data(
             self,
             X=X,
@@ -62,7 +74,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         self.projector_ = self.ordination_.projector(n_components=self.n_components_)
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X: DataLike, y: None = None) -> NDArray:
         check_is_fitted(self)
         X = _validate_data(
             self,
@@ -75,10 +87,10 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         )
         return (X - self.env_center_) @ self.projector_
 
-    def fit_transform(self, X, y):
+    def fit_transform(self, X: DataLike, y: DataLike) -> NDArray:
         return self.fit(X, y).transform(X)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.target_tags.required = True
         tags.target_tags.positive_only = True

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -55,7 +55,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     """
 
     def fit(self, X: DataLike, y: DataLike) -> Self:
-        X = _validate_data(
+        X_arr = _validate_data(
             self,
             X=X,
             reset=True,
@@ -68,7 +68,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         if len(y.shape) < 2:
             raise ValueError("`y` must be a 2D array.")
 
-        self.ordination_ = CCA(X, y)
+        self.ordination_ = CCA(X_arr, y)
         self.set_n_components()
         self.env_center_ = self.ordination_.env_center
         self.projector_ = self.ordination_.projector(n_components=self.n_components_)
@@ -76,7 +76,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
 
     def transform(self, X: DataLike, y: None = None) -> NDArray:
         check_is_fitted(self)
-        X = _validate_data(
+        X_arr = _validate_data(
             self,
             X=X,
             reset=False,
@@ -85,7 +85,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
             ensure_min_features=2,
             ensure_min_samples=1,
         )
-        return (X - self.env_center_) @ self.projector_
+        return (X_arr - self.env_center_) @ self.projector_
 
     def fit_transform(self, X: DataLike, y: DataLike) -> NDArray:
         return self.fit(X, y).transform(X)

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -74,7 +74,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         self.projector_ = self.ordination_.projector(n_components=self.n_components_)
         return self
 
-    def transform(self, X: DataLike, y: None = None) -> NDArray:
+    def transform(self, X: DataLike, y: None = None) -> NDArray[np.float64]:
         check_is_fitted(self)
         X_arr = _validate_data(
             self,
@@ -87,7 +87,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         )
         return (X_arr - self.env_center_) @ self.projector_
 
-    def fit_transform(self, X: DataLike, y: DataLike) -> NDArray:
+    def fit_transform(self, X: DataLike, y: DataLike) -> NDArray[np.float64]:
         return self.fit(X, y).transform(X)
 
     def __sklearn_tags__(self) -> Tags:

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -1,9 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from .._base import _validate_data
 from . import ComponentReducerMixin, StandardScalerWithDOF
 from ._ccora import CCorA
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from numpy.typing import NDArray
+    from sklearn.utils._tags import Tags
+
+    from ..types import DataLike
 
 
 class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
@@ -39,7 +51,7 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     Biometrika, 28(3/4), 321–377.
     """
 
-    def fit(self, X, y):
+    def fit(self, X: DataLike, y: DataLike) -> Self:
         _, y = _validate_data(self, X=X, y=y, reset=True, multi_output=True)
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
 
@@ -52,15 +64,15 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         self.projector_ = self.ordination_.projector(n_components=self.n_components_)
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X: DataLike, y: None = None) -> NDArray:
         check_is_fitted(self)
         _validate_data(self, X=X, reset=False, ensure_all_finite=True)
         return self.scaler_.transform(X) @ self.projector_
 
-    def fit_transform(self, X, y):
+    def fit_transform(self, X: DataLike, y: DataLike) -> NDArray:
         return self.fit(X, y).transform(X)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.target_tags.required = True
 

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -52,14 +52,14 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     """
 
     def fit(self, X: DataLike, y: DataLike) -> Self:
-        _, y = _validate_data(self, X=X, y=y, reset=True, multi_output=True)
+        _, y_arr = _validate_data(self, X=X, y=y, reset=True, multi_output=True)
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
 
-        if y.ndim == 1:
-            y = y.reshape(-1, 1)
-        y = StandardScalerWithDOF(ddof=1).fit_transform(y)
+        if y_arr.ndim == 1:
+            y_arr = y_arr.reshape(-1, 1)
+        y_arr = StandardScalerWithDOF(ddof=1).fit_transform(y_arr)
 
-        self.ordination_ = CCorA(self.scaler_.transform(X), y)
+        self.ordination_ = CCorA(self.scaler_.transform(X), y_arr)
         self.set_n_components()
         self.projector_ = self.ordination_.projector(n_components=self.n_components_)
         return self

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -12,6 +12,7 @@ from ._ccora import CCorA
 if TYPE_CHECKING:
     from typing import Self
 
+    import numpy as np
     from numpy.typing import NDArray
     from sklearn.utils._tags import Tags
 
@@ -64,12 +65,12 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
         self.projector_ = self.ordination_.projector(n_components=self.n_components_)
         return self
 
-    def transform(self, X: DataLike, y: None = None) -> NDArray:
+    def transform(self, X: DataLike, y: None = None) -> NDArray[np.float64]:
         check_is_fitted(self)
         _validate_data(self, X=X, reset=False, ensure_all_finite=True)
         return self.scaler_.transform(X) @ self.projector_
 
-    def fit_transform(self, X: DataLike, y: DataLike) -> NDArray:
+    def fit_transform(self, X: DataLike, y: DataLike) -> NDArray[np.float64]:
         return self.fit(X, y).transform(X)
 
     def __sklearn_tags__(self) -> Tags:

--- a/src/sknnr/transformers/_gbnode_transformer.py
+++ b/src/sknnr/transformers/_gbnode_transformer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import NDArray
 from sklearn._loss.loss import HalfBinomialLoss, HalfSquaredError
 from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor
 from sklearn.utils.validation import check_is_fitted

--- a/src/sknnr/transformers/_gbnode_transformer.py
+++ b/src/sknnr/transformers/_gbnode_transformer.py
@@ -287,7 +287,7 @@ class GBNodeTransformer(TreeNodeTransformer):
 
     def _set_tree_weights(
         self,
-        X: NDArray[np.object_ | np.number],
+        X: NDArray,
         y: list[NDArray[np.object_ | np.number]],
     ) -> list[NDArray[np.float64]]:
         tree_weights = []

--- a/src/sknnr/transformers/_gbnode_transformer.py
+++ b/src/sknnr/transformers/_gbnode_transformer.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 def train_improvement(
     est: GradientBoostingClassifier | GradientBoostingRegressor, X: NDArray, y: NDArray
-) -> NDArray:
+) -> NDArray[np.float64]:
     """
     Calculate tree weights as a function of the change in loss between
     successive trees in a gradient boosting estimator.  This behaves as a proxy
@@ -305,7 +305,7 @@ class GBNodeTransformer(TreeNodeTransformer):
 
         return tree_weights
 
-    def get_feature_names_out(self) -> NDArray:
+    def get_feature_names_out(self) -> NDArray[np.object_]:
         check_is_fitted(self, "estimators_")
         feature_names: list[str] = []
         for i, est in enumerate(self.estimators_):

--- a/src/sknnr/transformers/_gbnode_transformer.py
+++ b/src/sknnr/transformers/_gbnode_transformer.py
@@ -19,7 +19,9 @@ if TYPE_CHECKING:
 
 
 def train_improvement(
-    est: GradientBoostingClassifier | GradientBoostingRegressor, X: NDArray, y: NDArray
+    est: GradientBoostingClassifier | GradientBoostingRegressor,
+    X: NDArray[np.object_ | np.number],
+    y: NDArray[np.object_ | np.number],
 ) -> NDArray[np.float64]:
     """
     Calculate tree weights as a function of the change in loss between
@@ -284,7 +286,9 @@ class GBNodeTransformer(TreeNodeTransformer):
         return [est.n_trees_per_iteration_ for est in self.estimators_]
 
     def _set_tree_weights(
-        self, X: NDArray, y: list[NDArray]
+        self,
+        X: NDArray[np.object_ | np.number],
+        y: list[NDArray[np.object_ | np.number]],
     ) -> list[NDArray[np.float64]]:
         tree_weights = []
         if self.tree_weighting_method == "train_improvement":

--- a/src/sknnr/transformers/_gbnode_transformer.py
+++ b/src/sknnr/transformers/_gbnode_transformer.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy.typing import NDArray
 from sklearn._loss.loss import HalfBinomialLoss, HalfSquaredError
-from sklearn.base import BaseEstimator
 from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor
 from sklearn.utils.validation import check_is_fitted
 
@@ -15,6 +14,7 @@ if TYPE_CHECKING:
     from typing import Literal, Self
 
     from numpy.typing import NDArray
+    from sklearn.base import BaseEstimator
 
     from ..types import DataLike
 

--- a/src/sknnr/transformers/_gbnode_transformer.py
+++ b/src/sknnr/transformers/_gbnode_transformer.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 def train_improvement(
     est: GradientBoostingClassifier | GradientBoostingRegressor,
-    X: NDArray[np.object_ | np.number],
+    X: NDArray,
     y: NDArray[np.object_ | np.number],
 ) -> NDArray[np.float64]:
     """

--- a/src/sknnr/transformers/_gbnode_transformer.py
+++ b/src/sknnr/transformers/_gbnode_transformer.py
@@ -283,7 +283,9 @@ class GBNodeTransformer(TreeNodeTransformer):
     def _set_n_trees_per_iteration(self) -> list[int]:
         return [est.n_trees_per_iteration_ for est in self.estimators_]
 
-    def _set_tree_weights(self, X: DataLike, y: DataLike) -> list[NDArray[np.float64]]:
+    def _set_tree_weights(
+        self, X: NDArray, y: list[NDArray]
+    ) -> list[NDArray[np.float64]]:
         tree_weights = []
         if self.tree_weighting_method == "train_improvement":
             for est, target in zip(self.estimators_, y, strict=True):

--- a/src/sknnr/transformers/_gbnode_transformer.py
+++ b/src/sknnr/transformers/_gbnode_transformer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
@@ -10,6 +10,13 @@ from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegress
 from sklearn.utils.validation import check_is_fitted
 
 from ._tree_node_transformer import TreeNodeTransformer
+
+if TYPE_CHECKING:
+    from typing import Literal, Self
+
+    from numpy.typing import NDArray
+
+    from ..types import DataLike
 
 
 def train_improvement(
@@ -234,7 +241,7 @@ class GBNodeTransformer(TreeNodeTransformer):
         self.ccp_alpha = ccp_alpha
         self.tree_weighting_method = tree_weighting_method
 
-    def fit(self, X, y):
+    def fit(self, X: DataLike, y: DataLike) -> Self:
         gb_common_kwargs = dict(
             learning_rate=self.learning_rate,
             n_estimators=self.n_estimators,
@@ -277,7 +284,7 @@ class GBNodeTransformer(TreeNodeTransformer):
     def _set_n_trees_per_iteration(self) -> list[int]:
         return [est.n_trees_per_iteration_ for est in self.estimators_]
 
-    def _set_tree_weights(self, X, y) -> list[NDArray[np.float64]]:
+    def _set_tree_weights(self, X: DataLike, y: DataLike) -> list[NDArray[np.float64]]:
         tree_weights = []
         if self.tree_weighting_method == "train_improvement":
             for est, target in zip(self.estimators_, y, strict=True):
@@ -299,7 +306,7 @@ class GBNodeTransformer(TreeNodeTransformer):
 
     def get_feature_names_out(self) -> NDArray:
         check_is_fitted(self, "estimators_")
-        feature_names = []
+        feature_names: list[str] = []
         for i, est in enumerate(self.estimators_):
             # Regression and binary classification have 1 tree per iteration
             if est.n_trees_per_iteration_ == 1:

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -49,13 +49,13 @@ class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimat
         self.transform_ = np.linalg.inv(np.linalg.cholesky(covariance).T)
         return self
 
-    def transform(self, X: DataLike, y: None = None) -> NDArray:
+    def transform(self, X: DataLike, y: None = None) -> NDArray[np.float64]:
         check_is_fitted(self)
         _validate_data(self, X=X, ensure_all_finite="allow-nan", reset=False)
 
         return self.scaler_.transform(X) @ self.transform_
 
-    def fit_transform(self, X: DataLike, y: None = None) -> NDArray:
+    def fit_transform(self, X: DataLike, y: None = None) -> NDArray[np.float64]:
         return self.fit(X, y).transform(X)
 
     def __sklearn_tags__(self) -> Tags:

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -1,9 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from .._base import _validate_data
 from . import StandardScalerWithDOF
+
+if TYPE_CHECKING:
+    from typing import Self
+
+    from numpy.typing import NDArray
+    from sklearn.utils._tags import Tags
+
+    from ..types import DataLike
 
 
 class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
@@ -27,7 +39,7 @@ class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimat
         The Mahalanobis transformation matrix.
     """
 
-    def fit(self, X, y=None):
+    def fit(self, X: DataLike, y: None = None) -> Self:
         _validate_data(
             self, X=X, ensure_all_finite="allow-nan", reset=True, ensure_min_features=2
         )
@@ -37,16 +49,16 @@ class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimat
         self.transform_ = np.linalg.inv(np.linalg.cholesky(covariance).T)
         return self
 
-    def transform(self, X, y=None):
+    def transform(self, X: DataLike, y: None = None) -> NDArray:
         check_is_fitted(self)
         _validate_data(self, X=X, ensure_all_finite="allow-nan", reset=False)
 
         return self.scaler_.transform(X) @ self.transform_
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X: DataLike, y: None = None) -> NDArray:
         return self.fit(X, y).transform(X)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
 

--- a/src/sknnr/transformers/_rfnode_transformer.py
+++ b/src/sknnr/transformers/_rfnode_transformer.py
@@ -229,7 +229,7 @@ class RFNodeTransformer(TreeNodeTransformer):
     ) -> list[NDArray[np.float64]]:
         return uniform_weights(self.n_forests_, self.n_estimators)
 
-    def get_feature_names_out(self) -> NDArray:
+    def get_feature_names_out(self) -> NDArray[np.object_]:
         check_is_fitted(self, "estimators_")
         return np.asarray(
             [

--- a/src/sknnr/transformers/_rfnode_transformer.py
+++ b/src/sknnr/transformers/_rfnode_transformer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import NDArray
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.utils.validation import check_is_fitted
 

--- a/src/sknnr/transformers/_rfnode_transformer.py
+++ b/src/sknnr/transformers/_rfnode_transformer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.random import RandomState
@@ -10,6 +10,13 @@ from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.utils.validation import check_is_fitted
 
 from ._tree_node_transformer import TreeNodeTransformer, uniform_weights
+
+if TYPE_CHECKING:
+    from typing import Literal, Self
+
+    from numpy.typing import NDArray
+
+    from ..types import DataLike
 
 
 class RFNodeTransformer(TreeNodeTransformer):
@@ -175,7 +182,7 @@ class RFNodeTransformer(TreeNodeTransformer):
         self.max_samples = max_samples
         self.monotonic_cst = monotonic_cst
 
-    def fit(self, X, y):
+    def fit(self, X: DataLike, y: DataLike) -> Self:
         # Specialize the kwargs sent to initialize the random forests
         rf_common_kwargs = dict(
             n_estimators=self.n_estimators,
@@ -218,7 +225,7 @@ class RFNodeTransformer(TreeNodeTransformer):
     def _set_n_trees_per_iteration(self) -> list[int]:
         return [1] * self.n_forests_
 
-    def _set_tree_weights(self, X, y) -> list[NDArray[np.float64]]:
+    def _set_tree_weights(self, X: DataLike, y: DataLike) -> list[NDArray[np.float64]]:
         return uniform_weights(self.n_forests_, self.n_estimators)
 
     def get_feature_names_out(self) -> NDArray:

--- a/src/sknnr/transformers/_rfnode_transformer.py
+++ b/src/sknnr/transformers/_rfnode_transformer.py
@@ -226,7 +226,7 @@ class RFNodeTransformer(TreeNodeTransformer):
 
     def _set_tree_weights(
         self,
-        X: NDArray[np.object_ | np.number],
+        X: NDArray,
         y: list[NDArray[np.object_ | np.number]],
     ) -> list[NDArray[np.float64]]:
         return uniform_weights(self.n_forests_, self.n_estimators)

--- a/src/sknnr/transformers/_rfnode_transformer.py
+++ b/src/sknnr/transformers/_rfnode_transformer.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.random import RandomState
 from numpy.typing import NDArray
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.utils.validation import check_is_fitted
@@ -12,8 +10,10 @@ from sklearn.utils.validation import check_is_fitted
 from ._tree_node_transformer import TreeNodeTransformer, uniform_weights
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Literal, Self
 
+    from numpy.random import RandomState
     from numpy.typing import NDArray
 
     from ..types import DataLike

--- a/src/sknnr/transformers/_rfnode_transformer.py
+++ b/src/sknnr/transformers/_rfnode_transformer.py
@@ -224,7 +224,9 @@ class RFNodeTransformer(TreeNodeTransformer):
     def _set_n_trees_per_iteration(self) -> list[int]:
         return [1] * self.n_forests_
 
-    def _set_tree_weights(self, X: DataLike, y: DataLike) -> list[NDArray[np.float64]]:
+    def _set_tree_weights(
+        self, X: NDArray, y: list[NDArray]
+    ) -> list[NDArray[np.float64]]:
         return uniform_weights(self.n_forests_, self.n_estimators)
 
     def get_feature_names_out(self) -> NDArray:

--- a/src/sknnr/transformers/_rfnode_transformer.py
+++ b/src/sknnr/transformers/_rfnode_transformer.py
@@ -225,7 +225,9 @@ class RFNodeTransformer(TreeNodeTransformer):
         return [1] * self.n_forests_
 
     def _set_tree_weights(
-        self, X: NDArray, y: list[NDArray]
+        self,
+        X: NDArray[np.object_ | np.number],
+        y: list[NDArray[np.object_ | np.number]],
     ) -> list[NDArray[np.float64]]:
         return uniform_weights(self.n_forests_, self.n_estimators)
 

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -12,7 +12,7 @@ from ..utils import (
     get_feature_names_and_dtypes,
     is_categorical_dtype,
     is_nan_like,
-    is_number_like_type,
+    is_number_like_dtype,
     is_numpy_dtypelike,
 )
 
@@ -116,7 +116,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         # TODO: Handle overrides from user based on names
         # TODO: target_info.update(user_overrides)
         return {
-            k: "regression" if is_number_like_type(v) else "classification"
+            k: "regression" if is_number_like_dtype(v) else "classification"
             for k, v in target_info.items()
         }
 

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
     from sklearn.utils._tags import Tags
 
-    from ..types import DataDTypeLike, DataLike
+    from ..types import DataDTypeLike, DataLike, TreeClassifier, TreeRegressor
 
 
 def uniform_weights(n_forests: int, n_estimators: int) -> list[NDArray[np.float64]]:
@@ -124,8 +124,8 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         self,
         X: DataLike,
         y: DataLike,
-        regressor_cls: type[BaseEstimator],
-        classifier_cls: type[BaseEstimator],
+        regressor_cls: type[TreeRegressor],
+        classifier_cls: type[TreeClassifier],
         reg_kwargs: dict[str, Any],
         clf_kwargs: dict[str, Any],
     ) -> Self:

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -39,7 +39,7 @@ def uniform_weights(n_forests: int, n_estimators: int) -> list[NDArray[np.float6
 class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
     def _validate_and_promote_targets(
         self, y: DataLike, target_info: dict[Hashable, DataDTypeLike]
-    ) -> list[NDArray]:
+    ) -> list[NDArray[np.object_ | np.number]]:
         """
         Given target names and types, validate and promote each target in `y`.
 
@@ -167,7 +167,9 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
 
     @abstractmethod
     def _set_tree_weights(
-        self, X: NDArray, y: list[NDArray]
+        self,
+        X: NDArray[np.object_ | np.number],
+        y: list[NDArray[np.object_ | np.number]],
     ) -> list[NDArray[np.float64]]: ...
 
     @abstractmethod

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -18,7 +18,7 @@ from ..utils import (
 
 if TYPE_CHECKING:
     from collections.abc import Hashable
-    from typing import Literal, Self
+    from typing import Any, Literal, Self
 
     from numpy.typing import NDArray
     from sklearn.utils._tags import Tags
@@ -124,10 +124,10 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         self,
         X: DataLike,
         y: DataLike,
-        regressor_cls,
-        classifier_cls,
-        reg_kwargs,
-        clf_kwargs,
+        regressor_cls: BaseEstimator,
+        classifier_cls: BaseEstimator,
+        reg_kwargs: dict[str, Any],
+        clf_kwargs: dict[str, Any],
     ) -> Self:
         X = _validate_data(self, X=X, reset=True)
 

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -124,8 +124,8 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         self,
         X: DataLike,
         y: DataLike,
-        regressor_cls: BaseEstimator,
-        classifier_cls: BaseEstimator,
+        regressor_cls: type[BaseEstimator],
+        classifier_cls: type[BaseEstimator],
         reg_kwargs: dict[str, Any],
         clf_kwargs: dict[str, Any],
     ) -> Self:

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -71,7 +71,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
             # If the promoted dtype is categorical, promote the data to the
             # minimum numpy dtype.  Numpy does not support categorical dtypes,
             # but we need to retain the categorical dtype label to correctly route
-            # the target to a random forest classifier.
+            # the target to a tree-based classifier.
             if is_categorical_dtype(promoted_dtype):
                 target = np.asarray(target.tolist())
 

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import NDArray
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_array, check_is_fitted
 
@@ -12,7 +11,13 @@ from .._base import _validate_data
 from ..utils import get_feature_names_and_dtypes, is_nan_like, is_number_like_type
 
 if TYPE_CHECKING:
-    import pandas as pd
+    from collections.abc import Hashable
+    from typing import Literal, Self
+
+    from numpy.typing import NDArray
+    from sklearn.utils._tags import Tags
+
+    from ..types import DataLike, DTypeLike
 
 
 def uniform_weights(n_forests: int, n_estimators: int) -> list[NDArray[np.float64]]:
@@ -27,7 +32,7 @@ def uniform_weights(n_forests: int, n_estimators: int) -> list[NDArray[np.float6
 
 class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
     def _validate_and_promote_targets(
-        self, y: Any, target_info: dict[str, np.dtype | pd.CategoricalDtype]
+        self, y: DataLike, target_info: dict[Hashable, DTypeLike]
     ) -> list[NDArray]:
         """
         Given target names and types, validate and promote each target in `y`.
@@ -98,8 +103,8 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         return targets
 
     def _set_estimator_types(
-        self, target_info: dict[str, Any]
-    ) -> dict[str, Literal["regression", "classification"]]:
+        self, target_info: dict[Hashable, DTypeLike]
+    ) -> dict[Hashable, Literal["regression", "classification"]]:
         """Set the estimator type to use for each target in `y`."""
 
         # TODO: Handle overrides from user based on names
@@ -109,7 +114,15 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
             for k, v in target_info.items()
         }
 
-    def _fit(self, X, y, regressor_cls, classifier_cls, reg_kwargs, clf_kwargs):
+    def _fit(
+        self,
+        X: DataLike,
+        y: DataLike,
+        regressor_cls,
+        classifier_cls,
+        reg_kwargs,
+        clf_kwargs,
+    ) -> Self:
         X = _validate_data(self, X=X, reset=True)
 
         if y is None:
@@ -147,12 +160,14 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
     def _set_n_trees_per_iteration(self) -> list[int]: ...
 
     @abstractmethod
-    def _set_tree_weights(self, X, y) -> list[NDArray[np.float64]]: ...
+    def _set_tree_weights(
+        self, X: DataLike, y: DataLike
+    ) -> list[NDArray[np.float64]]: ...
 
     @abstractmethod
-    def fit(self, X, y): ...
+    def fit(self, X: DataLike, y: DataLike) -> Self: ...
 
-    def transform(self, X):
+    def transform(self, X: DataLike) -> NDArray[np.int64]:
         check_is_fitted(self)
         X = _validate_data(
             self,
@@ -178,10 +193,10 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
             node_ids.append(est_node_ids)
         return np.hstack(node_ids).astype("int64")
 
-    def fit_transform(self, X, y):
+    def fit_transform(self, X: DataLike, y: DataLike) -> NDArray[np.int64]:
         return self.fit(X, y).transform(X)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.target_tags.required = True
         tags.transformer_tags.preserves_dtype = ["int64"]

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -142,7 +142,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         target_info = get_feature_names_and_dtypes(y)
 
         # Validate and promote targets within `y`
-        y = self._validate_and_promote_targets(y, target_info)
+        y_arr = self._validate_and_promote_targets(y, target_info)
 
         # Assign estimator types based on the target dtypes
         self.estimator_type_dict_ = self._set_estimator_types(target_info)
@@ -155,11 +155,11 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
             regressor_cls(**reg_kwargs).fit(X_arr, target)
             if target_idx_to_estimator_type[i] == "regression"
             else classifier_cls(**clf_kwargs).fit(X_arr, target)
-            for i, target in enumerate(y)
+            for i, target in enumerate(y_arr)
         ]
         self.n_forests_ = len(self.estimators_)
         self.n_trees_per_iteration_ = self._set_n_trees_per_iteration()
-        self.tree_weights_ = self._set_tree_weights(X_arr, y)
+        self.tree_weights_ = self._set_tree_weights(X_arr, y_arr)
         return self
 
     @abstractmethod
@@ -168,7 +168,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
     @abstractmethod
     def _set_tree_weights(
         self,
-        X: NDArray[np.object_ | np.number],
+        X: NDArray,
         y: list[NDArray[np.object_ | np.number]],
     ) -> list[NDArray[np.float64]]: ...
 

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -8,7 +8,13 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_array, check_is_fitted
 
 from .._base import _validate_data
-from ..utils import get_feature_names_and_dtypes, is_nan_like, is_number_like_type
+from ..utils import (
+    get_feature_names_and_dtypes,
+    is_categorical_dtype,
+    is_nan_like,
+    is_number_like_type,
+    is_numpy_dtypelike,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Hashable
@@ -17,7 +23,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
     from sklearn.utils._tags import Tags
 
-    from ..types import DataLike, DTypeLike
+    from ..types import DataDTypeLike, DataLike
 
 
 def uniform_weights(n_forests: int, n_estimators: int) -> list[NDArray[np.float64]]:
@@ -32,7 +38,7 @@ def uniform_weights(n_forests: int, n_estimators: int) -> list[NDArray[np.float6
 
 class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
     def _validate_and_promote_targets(
-        self, y: DataLike, target_info: dict[Hashable, DTypeLike]
+        self, y: DataLike, target_info: dict[Hashable, DataDTypeLike]
     ) -> list[NDArray]:
         """
         Given target names and types, validate and promote each target in `y`.
@@ -66,27 +72,27 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
             # minimum numpy dtype.  Numpy does not support categorical dtypes,
             # but we need to retain the categorical dtype label to correctly route
             # the target to a random forest classifier.
-            if str(promoted_dtype) == "category":
+            if is_categorical_dtype(promoted_dtype):
                 target = np.asarray(target.tolist())
 
-            # Check for targets with mixed numeric and non-numeric elements.
-            # Safe promotion of numeric types to other numeric types is
-            # allowed (e.g. bool to int, int to float), but potentially unsafe
-            # promotion from numeric to non-numeric types is not allowed
-            # (e.g. int to str, float to str).
-            elif np.issubdtype(promoted_dtype, np.str_) and (
-                non_string_types := {
-                    type(v) for v in target if not np.issubdtype(type(v), np.str_)
-                }
-            ):
-                raise ValueError(
-                    f"Target {name} has non-string types ({non_string_types}) "
-                    f"that cannot be safely converted to a string dtype "
-                    f"({promoted_dtype})."
-                )
+            elif is_numpy_dtypelike(promoted_dtype):
+                # Check for targets with mixed numeric and non-numeric elements.
+                # Safe promotion of numeric types to other numeric types is
+                # allowed (e.g. bool to int, int to float), but potentially unsafe
+                # promotion from numeric to non-numeric types is not allowed
+                # (e.g. int to str, float to str).
+                if np.issubdtype(promoted_dtype, np.str_) and (
+                    non_string_types := {
+                        type(v) for v in target if not np.issubdtype(type(v), np.str_)
+                    }
+                ):
+                    raise ValueError(
+                        f"Target {name} has non-string types ({non_string_types}) "
+                        f"that cannot be safely converted to a string dtype "
+                        f"({promoted_dtype})."
+                    )
 
-            # Otherwise, promote the target to the minimum numpy dtype
-            else:
+                # Otherwise, promote the target to the minimum numpy dtype
                 target = target.astype(promoted_dtype)
 
             # Check for any other issues with the target when paired with the
@@ -103,7 +109,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         return targets
 
     def _set_estimator_types(
-        self, target_info: dict[Hashable, DTypeLike]
+        self, target_info: dict[Hashable, DataDTypeLike]
     ) -> dict[Hashable, Literal["regression", "classification"]]:
         """Set the estimator type to use for each target in `y`."""
 

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -129,7 +129,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         reg_kwargs: dict[str, Any],
         clf_kwargs: dict[str, Any],
     ) -> Self:
-        X = _validate_data(self, X=X, reset=True)
+        X_arr = _validate_data(self, X=X, reset=True)
 
         if y is None:
             msg = (
@@ -152,14 +152,14 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
             i: v for i, (_, v) in enumerate(self.estimator_type_dict_.items())
         }
         self.estimators_ = [
-            regressor_cls(**reg_kwargs).fit(X, target)
+            regressor_cls(**reg_kwargs).fit(X_arr, target)
             if target_idx_to_estimator_type[i] == "regression"
-            else classifier_cls(**clf_kwargs).fit(X, target)
+            else classifier_cls(**clf_kwargs).fit(X_arr, target)
             for i, target in enumerate(y)
         ]
         self.n_forests_ = len(self.estimators_)
         self.n_trees_per_iteration_ = self._set_n_trees_per_iteration()
-        self.tree_weights_ = self._set_tree_weights(X, y)
+        self.tree_weights_ = self._set_tree_weights(X_arr, y)
         return self
 
     @abstractmethod
@@ -175,7 +175,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
 
     def transform(self, X: DataLike) -> NDArray[np.int64]:
         check_is_fitted(self)
-        X = _validate_data(
+        X_arr = _validate_data(
             self,
             X=X,
             reset=False,
@@ -186,7 +186,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         # Get the node IDs for each tree in each forest
         node_ids = []
         for est in self.estimators_:
-            est_node_ids = est.apply(X)
+            est_node_ids = est.apply(X_arr)
             # In the case of some multi-class estimators (e.g.
             # GradientBoostingClassifier), the output of `apply` is 3D (n_samples,
             # n_estimators, n_classes). First swap axes to get (n_samples,

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -161,7 +161,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
 
     @abstractmethod
     def _set_tree_weights(
-        self, X: DataLike, y: DataLike
+        self, X: NDArray, y: list[NDArray]
     ) -> list[NDArray[np.float64]]: ...
 
     @abstractmethod

--- a/src/sknnr/types.py
+++ b/src/sknnr/types.py
@@ -9,6 +9,12 @@ if TYPE_CHECKING:
 
     from pandas import CategoricalDtype
     from pandas.api.extensions import ExtensionDtype
+    from sklearn.ensemble import (
+        GradientBoostingClassifier,
+        GradientBoostingRegressor,
+        RandomForestClassifier,
+        RandomForestRegressor,
+    )
 
 NumpyDTypeLike: TypeAlias = DTypeLike
 """Any data type that can be used in a numpy array."""
@@ -18,6 +24,9 @@ AnyDTypeLike = Union[NumpyDTypeLike, "ExtensionDtype"]
 
 DataDTypeLike = Union[NumpyDTypeLike, "CategoricalDtype"]
 """Data types used for features or targets, i.e. Numpy and Pandas categorical dtypes."""
+
+TreeRegressor = Union["RandomForestRegressor", "GradientBoostingRegressor"]
+TreeClassifier = Union["RandomForestClassifier", "GradientBoostingClassifier"]
 
 
 class DataFrameLike(Protocol):

--- a/src/sknnr/types.py
+++ b/src/sknnr/types.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol, Union
 
+from numpy.typing import ArrayLike
+
 if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
 
@@ -11,15 +13,31 @@ if TYPE_CHECKING:
 DTypeLike = Union["NDTypeLike", "ExtensionDtype"]
 
 
-class DataFrameLike(Protocol):
+class Indexed(Protocol):
+    """A protocol for objects that have an index, such as dataframes and series."""
+
+    index: Sequence[Hashable]
+
+
+class DataFrameLike(Indexed, Protocol):
     """A protocol for dataframe-like objects, such as pandas and polars DataFrames."""
 
     columns: Sequence[Hashable]
     dtypes: Sequence[DTypeLike]
 
 
-class SeriesLike(Protocol):
+class SeriesLike(Indexed, Protocol):
     """A protocol for series-like objects, such as pandas and polars Series."""
 
     name: Hashable | None
     dtype: DTypeLike
+
+
+DataLike = DataFrameLike | SeriesLike | ArrayLike
+"""
+Data structures that can be used as input to Scikit-learn estimators, including labeled
+and unlabeled arrays.
+
+This broadly follows the "array-like" definition from Scikit-learn:
+https://scikit-learn.org/stable/glossary.html#term-array-like
+"""

--- a/src/sknnr/types.py
+++ b/src/sknnr/types.py
@@ -2,29 +2,36 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol, Union
 
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, DTypeLike
 
 if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
 
-    from numpy.typing import DTypeLike as NDTypeLike
+    from pandas import CategoricalDtype
     from pandas.api.extensions import ExtensionDtype
 
-DTypeLike = Union["NDTypeLike", "ExtensionDtype"]
+NumpyDTypeLike = DTypeLike
+"""Any data type that can be used in a numpy array."""
+
+AnyDTypeLike = Union[NumpyDTypeLike, "ExtensionDtype"]
+"""Any Numpy or Pandas data type, including extension types."""
+
+DataDTypeLike = Union[NumpyDTypeLike, "CategoricalDtype"]
+"""Data types used for features or targets, i.e. Numpy and Pandas categorical dtypes."""
 
 
 class DataFrameLike(Protocol):
     """A protocol for dataframe-like objects, such as pandas and polars DataFrames."""
 
     columns: Sequence[Hashable]
-    dtypes: Sequence[DTypeLike]
+    dtypes: Sequence[AnyDTypeLike]
 
 
 class SeriesLike(Protocol):
     """A protocol for series-like objects, such as pandas and polars Series."""
 
     name: Hashable | None
-    dtype: DTypeLike
+    dtype: AnyDTypeLike
 
 
 DataLike = DataFrameLike | SeriesLike | ArrayLike

--- a/src/sknnr/types.py
+++ b/src/sknnr/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, Union
+from typing import TYPE_CHECKING, Protocol, TypeAlias, Union
 
 from numpy.typing import ArrayLike, DTypeLike
 
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pandas import CategoricalDtype
     from pandas.api.extensions import ExtensionDtype
 
-NumpyDTypeLike = DTypeLike
+NumpyDTypeLike: TypeAlias = DTypeLike
 """Any data type that can be used in a numpy array."""
 
 AnyDTypeLike = Union[NumpyDTypeLike, "ExtensionDtype"]

--- a/src/sknnr/types.py
+++ b/src/sknnr/types.py
@@ -13,20 +13,14 @@ if TYPE_CHECKING:
 DTypeLike = Union["NDTypeLike", "ExtensionDtype"]
 
 
-class Indexed(Protocol):
-    """A protocol for objects that have an index, such as dataframes and series."""
-
-    index: Sequence[Hashable]
-
-
-class DataFrameLike(Indexed, Protocol):
+class DataFrameLike(Protocol):
     """A protocol for dataframe-like objects, such as pandas and polars DataFrames."""
 
     columns: Sequence[Hashable]
     dtypes: Sequence[DTypeLike]
 
 
-class SeriesLike(Indexed, Protocol):
+class SeriesLike(Protocol):
     """A protocol for series-like objects, such as pandas and polars Series."""
 
     name: Hashable | None

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -5,10 +5,19 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable
+    from collections.abc import Hashable, Sequence
     from typing import TypeGuard
 
-    from ..types import DataFrameLike, DataLike, DTypeLike, SeriesLike
+    from pandas import CategoricalDtype
+
+    from ..types import (
+        AnyDTypeLike,
+        DataDTypeLike,
+        DataFrameLike,
+        DataLike,
+        NumpyDTypeLike,
+        SeriesLike,
+    )
 
 
 def is_dataframe_like(obj: object) -> TypeGuard[DataFrameLike]:
@@ -29,18 +38,17 @@ def is_series_like(obj: object) -> TypeGuard[SeriesLike]:
     return hasattr(obj, "name") and hasattr(obj, "dtype")
 
 
-def is_number_like_type(t: DTypeLike) -> bool:
+def is_number_like_type(t: AnyDTypeLike) -> bool:
     """
     Check if `t` is a number-like type.  For most types, np.issubdtype will
     correctly identify the type.  For pandas extension types, we can check the
     kind of the type.
     """
-    try:
-        return np.issubdtype(t, np.number)  # type: ignore[arg-type]
-    except TypeError as e:
-        if kind := getattr(t, "kind", None):
-            return kind in "iuf"
-        raise TypeError(f"Unsupported type {t}") from e
+    if is_numpy_dtypelike(t):
+        return np.issubdtype(t, np.number)
+    if kind := getattr(t, "kind", None):
+        return kind in "iuf"
+    raise TypeError(f"Unsupported type {t}")
 
 
 def is_nan_like(x: object) -> bool:
@@ -50,6 +58,25 @@ def is_nan_like(x: object) -> bool:
         or (isinstance(x, float) and np.isnan(x))
         or x.__class__.__name__ == "NAType"
     )
+
+
+def is_numpy_dtypelike(t: AnyDTypeLike) -> TypeGuard[NumpyDTypeLike]:
+    """
+    Check if `t` is a valid Numpy dtype. This narrows the type by excluding Pandas
+    extension types like categorical.
+    """
+    try:
+        np.dtype(t)  # type: ignore[arg-type]
+        return True
+    except TypeError:
+        return False
+
+
+def is_categorical_dtype(t: AnyDTypeLike) -> TypeGuard[CategoricalDtype]:
+    """
+    Check if `t` is a categorical dtype using duck-typing.
+    """
+    return str(t) == "category"
 
 
 def get_feature_names(obj: DataLike | None) -> list[Hashable]:
@@ -69,7 +96,7 @@ def get_feature_names(obj: DataLike | None) -> list[Hashable]:
     return [str(i) for i in range(arr.shape[1])]
 
 
-def get_minimum_dtypes(obj: DataLike) -> list[DTypeLike]:
+def get_minimum_dtypes(obj: DataLike) -> list[NumpyDTypeLike]:
     """
     Return the smallest numpy dtype that can accommodate all data for each
     column in obj.
@@ -80,7 +107,7 @@ def get_minimum_dtypes(obj: DataLike) -> list[DTypeLike]:
     return [np.asarray(arr[:, i].tolist()).dtype for i in range(arr.shape[1])]
 
 
-def get_feature_dtypes(obj: DataLike | None) -> list[DTypeLike]:
+def get_feature_dtypes(obj: DataLike | None) -> Sequence[DataDTypeLike]:
     """
     Get numpy dtypes of the features in `obj`, promoting dtypes as necessary to
     the smallest type that can accommodate all data elements in that feature.
@@ -104,18 +131,20 @@ def get_feature_dtypes(obj: DataLike | None) -> list[DTypeLike]:
         native_dtypes = getattr(obj.dtypes, "values", obj.dtypes)
         promoted_dtypes = get_minimum_dtypes(obj)
         return [
-            p_dtype if str(n_dtype) != "category" else n_dtype
+            n_dtype if is_categorical_dtype(n_dtype) else p_dtype
             for p_dtype, n_dtype in zip(promoted_dtypes, native_dtypes, strict=True)
         ]
     if is_series_like(obj):
         native_dtype = obj.dtype
         promoted_dtype = get_minimum_dtypes(obj)[0]
-        return [promoted_dtype if str(native_dtype) != "category" else native_dtype]
+        return [native_dtype if is_categorical_dtype(native_dtype) else promoted_dtype]
 
     return get_minimum_dtypes(obj)
 
 
-def get_feature_names_and_dtypes(obj: DataLike | None) -> dict[Hashable, DTypeLike]:
+def get_feature_names_and_dtypes(
+    obj: DataLike | None,
+) -> dict[Hashable, DataDTypeLike]:
     """
     Get the names and dtypes of the features in `obj` and return as dict.
 

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -4,20 +4,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ..types import DataFrameLike, DTypeLike, SeriesLike
-
 if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
     from typing import TypeGuard
 
     from ..types import DataFrameLike, DTypeLike, SeriesLike
-
-
-def _has_all_attrs(obj: object, protocol: type) -> bool:
-    """
-    Check if an object satisfies the attributes of a protocol.
-    """
-    return all(hasattr(obj, attr) for attr in protocol.__annotations__)
 
 
 def is_dataframe_like(obj: object) -> TypeGuard[DataFrameLike]:
@@ -26,7 +17,7 @@ def is_dataframe_like(obj: object) -> TypeGuard[DataFrameLike]:
     for pandas and polars DataFrames without the need to import those packages
     explicitly.
     """
-    return _has_all_attrs(obj, DataFrameLike)
+    return hasattr(obj, "columns") and hasattr(obj, "dtypes")
 
 
 def is_series_like(obj: object) -> TypeGuard[SeriesLike]:
@@ -35,7 +26,7 @@ def is_series_like(obj: object) -> TypeGuard[SeriesLike]:
     for pandas and polars Series without the need to import those packages
     explicitly.
     """
-    return _has_all_attrs(obj, SeriesLike)
+    return hasattr(obj, "name") and hasattr(obj, "dtype")
 
 
 def is_number_like_type(t: DTypeLike) -> bool:

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable, Sequence
+    from collections.abc import Hashable
     from typing import TypeGuard
 
-    from ..types import DataFrameLike, DTypeLike, SeriesLike
+    from ..types import DataFrameLike, DataLike, DTypeLike, SeriesLike
 
 
 def is_dataframe_like(obj: object) -> TypeGuard[DataFrameLike]:
@@ -52,9 +52,7 @@ def is_nan_like(x: object) -> bool:
     )
 
 
-def get_feature_names(
-    obj: None | Sequence | DataFrameLike | SeriesLike,
-) -> list[Hashable]:
+def get_feature_names(obj: DataLike | None) -> list[Hashable]:
     """
     Get the names of the features in `obj`. If no names are found, return
     a list of strings with the feature index.
@@ -71,7 +69,7 @@ def get_feature_names(
     return [str(i) for i in range(arr.shape[1])]
 
 
-def get_minimum_dtypes(obj: Sequence | DataFrameLike | SeriesLike) -> list[DTypeLike]:
+def get_minimum_dtypes(obj: DataLike) -> list[DTypeLike]:
     """
     Return the smallest numpy dtype that can accommodate all data for each
     column in obj.
@@ -82,9 +80,7 @@ def get_minimum_dtypes(obj: Sequence | DataFrameLike | SeriesLike) -> list[DType
     return [np.asarray(arr[:, i].tolist()).dtype for i in range(arr.shape[1])]
 
 
-def get_feature_dtypes(
-    obj: None | Sequence | DataFrameLike | SeriesLike,
-) -> list[DTypeLike]:
+def get_feature_dtypes(obj: DataLike | None) -> list[DTypeLike]:
     """
     Get numpy dtypes of the features in `obj`, promoting dtypes as necessary to
     the smallest type that can accommodate all data elements in that feature.
@@ -119,9 +115,7 @@ def get_feature_dtypes(
     return get_minimum_dtypes(obj)
 
 
-def get_feature_names_and_dtypes(
-    obj: None | Sequence | DataFrameLike | SeriesLike,
-) -> dict[Hashable, DTypeLike]:
+def get_feature_names_and_dtypes(obj: DataLike | None) -> dict[Hashable, DTypeLike]:
     """
     Get the names and dtypes of the features in `obj` and return as dict.
 

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -38,11 +38,11 @@ def is_series_like(obj: object) -> TypeGuard[SeriesLike]:
     return hasattr(obj, "name") and hasattr(obj, "dtype")
 
 
-def is_number_like_type(t: AnyDTypeLike) -> bool:
+def is_number_like_dtype(t: AnyDTypeLike) -> bool:
     """
-    Check if `t` is a number-like type.  For most types, np.issubdtype will
-    correctly identify the type.  For pandas extension types, we can check the
-    kind of the type.
+    Check if `t` is a number-like dtype.  For most dtypes, np.issubdtype will
+    correctly identify the type.  For pandas extension dtypes, we can check the
+    kind of the dtype.
     """
     if is_numpy_dtypelike(t):
         return np.issubdtype(t, np.number)

--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -4,11 +4,20 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from ..types import DataFrameLike, DTypeLike, SeriesLike
+
 if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
     from typing import TypeGuard
 
     from ..types import DataFrameLike, DTypeLike, SeriesLike
+
+
+def _has_all_attrs(obj: object, protocol: type) -> bool:
+    """
+    Check if an object satisfies the attributes of a protocol.
+    """
+    return all(hasattr(obj, attr) for attr in protocol.__annotations__)
 
 
 def is_dataframe_like(obj: object) -> TypeGuard[DataFrameLike]:
@@ -17,7 +26,7 @@ def is_dataframe_like(obj: object) -> TypeGuard[DataFrameLike]:
     for pandas and polars DataFrames without the need to import those packages
     explicitly.
     """
-    return hasattr(obj, "columns") and hasattr(obj, "dtypes")
+    return _has_all_attrs(obj, DataFrameLike)
 
 
 def is_series_like(obj: object) -> TypeGuard[SeriesLike]:
@@ -26,7 +35,7 @@ def is_series_like(obj: object) -> TypeGuard[SeriesLike]:
     for pandas and polars Series without the need to import those packages
     explicitly.
     """
-    return hasattr(obj, "name") and hasattr(obj, "dtype")
+    return _has_all_attrs(obj, SeriesLike)
 
 
 def is_number_like_type(t: DTypeLike) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-import numpy as np
 import pytest
-from numpy.typing import NDArray
 from sklearn.model_selection import train_test_split
 
 from sknnr.datasets import load_moscow_stjoes
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
 
 
 @dataclass

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
-from numpy.typing import NDArray
 from sklearn import config_context
 from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors import KNeighborsRegressor
@@ -20,6 +21,9 @@ from sknnr import (
     RFNNRegressor,
 )
 from sknnr.datasets import load_moscow_stjoes
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 TEST_ESTIMATORS = [
     RawKNNRegressor,

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -135,7 +135,7 @@ def get_estimator_xfail_checks(estimator) -> dict[str, str]:
 
 
 @pytest.fixture
-def X_y_yfit() -> tuple[NDArray, NDArray, NDArray]:
+def X_y_yfit() -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
     """Return X, y, and y_fit arrays for testing y_fit compatible estimators."""
     X, y = load_moscow_stjoes(return_X_y=True)
     # Arbitrary split with a constant to prevent zero sum rows

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ from sknnr.utils import (
     get_feature_names,
     is_dataframe_like,
     is_nan_like,
-    is_number_like_type,
+    is_number_like_dtype,
     is_numpy_dtypelike,
     is_series_like,
 )
@@ -64,9 +64,9 @@ def test_is_series_like(obj, expected):
         (type(None), False),
     ],
 )
-def test_is_number_like_type(t, expected):
-    """Test is_number_like_type returns expected results."""
-    assert is_number_like_type(t) is expected
+def test_is_number_like_dtype(t, expected):
+    """Test is_number_like_dtype returns expected results."""
+    assert is_number_like_dtype(t) is expected
 
 
 @pytest.mark.parametrize("x", [None, np.nan, float("nan"), pd.NA])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from sknnr.utils import (
     is_dataframe_like,
     is_nan_like,
     is_number_like_type,
+    is_numpy_dtypelike,
     is_series_like,
 )
 
@@ -148,3 +149,23 @@ def test_promoted_feature_dtypes(obj, expected):
     elements with mixed dtypes.
     """
     assert get_feature_dtypes(obj) == expected
+
+
+@pytest.mark.parametrize(
+    ("t", "expected"),
+    [
+        (int, True),
+        (float, True),
+        (np.int32, True),
+        (np.float64, True),
+        (pd.CategoricalDtype(), False),
+        (pd.IntervalDtype(), False),
+        (pd.Int16Dtype(), False),
+        (pd.Float32Dtype(), False),
+        (pd.StringDtype(), False),
+        (pd.BooleanDtype(), False),
+    ],
+)
+def test_is_numpy_dtypelike(t, expected):
+    """Test is_numpy_dtypelike returns expected results."""
+    assert is_numpy_dtypelike(t) is expected


### PR DESCRIPTION
Along with #109 and #110, this is another step (maybe the final step?) towards #7, by adding typing for all estimators. The only modules I haven't currently touched are the `_cca` and `_ccora` implementations, since I know there have been some significant efforts to refactor those in #60 that might influence how we approach typing.

This PR includes more changes and decisions that aren't strictly typing than the other two, so I'll outline those below.

## Mixin class inheritance

Correctly typing the mixins was tricky, since they rely on methods and attributes of the class that they expect to be mixed into. I played around with typing `self` as a protocol, but found that required repeating a lot of our base classes as protocols, didn't work for every case, and only enforced typing when methods are called.

Instead, I ended up loosely following the recommendations in [this blog post](https://adamj.eu/tech/2025/05/01/python-type-hints-mixin-classes/), which suggests using shared base classes to satisfy type checks. 

For example, `IndependentPredictorMixin` now inherits from `KNeighborsRegressor`, which ensures that it implements `predict` and `score` with optional `X` arguments. `YFitMixin` inherits from `TransformedKNeighborsRegressor`, since that defines the `_get_transformer` method (that also required changing the definition order). I don't think this leads to any functional changes, but it's worth thinking about MRO a little more to make sure it doesn't break anything.

## DataLike

Another challenge was coming up with a good type to represent the X and y inputs for estimator methods. For now, I'm using a union of Numpy `ArrayLike` and the `DataFrameLike` and `SeriesLike` protocols that I called `DataLike`, but I'm not totally sure that's the right definition or the right name. 

The [Microsoft typestubs for scikit-learn](https://github.com/microsoft/python-type-stubs/blob/main/stubs/sklearn/_typing.pyi) seem to use `MatrixLike` for `X` and `MatrixLike | ArrayLike` for `y`, where `MatrixLike` is a union of Numpy `ArrayLike`, `pd.DataFrame`, and `scipy.sparse.spmatrix`. Maybe we should go with something like that, but replacing the specific Pandas type with the `DataFrameLike` protocol? I also wasn't sure whether we should name our type `MatrixLike` for consistency, or change it to avoid confusion with our slightly different definition.

## Type-checking rules

This PR involved a lot of new imports, most of which are only used for typing. To help stay consistent and avoid typing-only imports at runtime, I added the [flake8-type-checking](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) rules to Ruff.

## PR order

I made this PR on top of #110 since it builds on the `types` module introduced there. I'll leave this is a draft until that's merged, then rebase this as needed.