### PR TITLE
Include typed dependencies in `mypy` pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.2
     hooks:
       - id: mypy
         exclude: ^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,7 @@ repos:
     hooks:
       - id: mypy
         exclude: ^tests/
-        args: [--ignore-missing-imports]
+        additional_dependencies:
+          - numpy
+          - pandas-stubs
+          - scipy-stubs

--- a/src/sknnr/_gbnn.py
+++ b/src/sknnr/_gbnn.py
@@ -182,7 +182,7 @@ class GBNNRegressor(WeightedTreesNNRegressor):
         n_iter_no_change: int | None = None,
         tol: float = 0.0001,
         ccp_alpha: float = 0.0,
-        forest_weights: Literal["uniform"] | ArrayLike[float] = "uniform",
+        forest_weights: Literal["uniform"] | ArrayLike = "uniform",
         tree_weighting_method: Literal[
             "train_improvement", "uniform"
         ] = "train_improvement",

--- a/src/sknnr/_rfnn.py
+++ b/src/sknnr/_rfnn.py
@@ -180,7 +180,7 @@ class RFNNRegressor(WeightedTreesNNRegressor):
         ccp_alpha: float = 0.0,
         max_samples: int | float | None = None,
         monotonic_cst: list[int] | None = None,
-        forest_weights: Literal["uniform"] | ArrayLike[float] = "uniform",
+        forest_weights: Literal["uniform"] | ArrayLike = "uniform",
         n_neighbors: int = 5,
         weights: Literal["uniform", "distance"] | Callable = "uniform",
     ):

--- a/src/sknnr/_weighted_trees.py
+++ b/src/sknnr/_weighted_trees.py
@@ -41,7 +41,7 @@ class WeightedTreesNNRegressor(YFitMixin, TransformedKNeighborsRegressor):
     """
 
     transformer_: TreeNodeTransformer
-    forest_weights: Literal["uniform"] | ArrayLike[float]
+    forest_weights: Literal["uniform"] | ArrayLike
 
     def __init__(
         self,

--- a/src/sknnr/datasets/_base.py
+++ b/src/sknnr/datasets/_base.py
@@ -207,7 +207,7 @@ def load_dataset_from_csv_filenames(
         file_name=target_filename, module_name=module_name
     )
 
-    dataset = Dataset(
+    array_ds = Dataset(
         index=index,
         data=data,
         target=target,
@@ -217,9 +217,10 @@ def load_dataset_from_csv_filenames(
     )
 
     if as_frame:
-        dataset = _dataset_as_frame(dataset)
+        frame_ds = _dataset_as_frame(array_ds)
+        return (frame_ds.data, frame_ds.target) if return_X_y else frame_ds
 
-    return (dataset.data, dataset.target) if return_X_y else dataset
+    return (array_ds.data, array_ds.target) if return_X_y else array_ds
 
 
 @overload


### PR DESCRIPTION
Closes #115 by including Numpy and stubs for Pandas and SciPy in the `mypy` pre-commit environment, allowing our functions that depend on those packages to be correctly type-checked. scikit-learn currently has [no official stubs](https://github.com/scikit-learn/scikit-learn/discussions/25307). Microsoft maintains [their own stubs](https://github.com/microsoft/python-type-stubs/tree/main/stubs/sklearn) that they use for language server support, but they're not independently installable. When I tried to [install the entire stub library](https://github.com/microsoft/python-type-stubs#installing-our-stubs) into `mypy`, it led to a lot of type errors that seemed to arise from incomplete or incorrect stubs, rather than issues on our end, so I think it's probably better to leave those out for now. 

Adding the stubs raised a few minor typing errors, which this also fixes.