### PR TITLE
Pin `scikit-learn` runtime version to `>=1.6.0`

### DIFF
--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -13,6 +13,6 @@ pip install sknnr --pre
 ## Dependencies
 
 - Python >= 3.11
-- scikit-learn >= 1.2
+- scikit-learn >= 1.6.0
 - numpy
 - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = ["pre-commit"]
 
 [tool.hatch.envs.test]
 dependencies = [
-    "scikit-learn>=1.6.0",
     "pytest",
     "pytest-cov",
     "pytest-regressions",
@@ -51,11 +50,7 @@ template = "test"
 python = ["3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.envs.docs]
-dependencies = [
-    "mkdocs<2.0.0", 
-    "mkdocs-material", 
-    "mkdocstrings[python]"
-]
+dependencies = ["mkdocs<2.0.0", "mkdocs-material", "mkdocstrings[python]"]
 
 [tool.hatch.envs.docs.scripts]
 serve = "mkdocs serve --config-file docs/mkdocs.yml --livereload --watch ./README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Matt Gregory", email = "matt.gregory@oregonstate.edu" },
     { name = "Aaron Zuspan", email = "aaron.zuspan@oregonstate.edu" },
 ]
-dependencies = ["numpy", "scikit-learn>=1.2", "scipy"]
+dependencies = ["numpy", "scikit-learn>=1.6.0", "scipy"]
 
 [project.urls]
 Homepage = "https://github.com/lemma-osu/sknnr"

--- a/src/sknnr/_base.py
+++ b/src/sknnr/_base.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.neighbors import KNeighborsRegressor
-from sklearn.utils.validation import _is_arraylike, check_is_fitted
+from sklearn.utils.validation import _is_arraylike, check_is_fitted, validate_data
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -18,65 +18,6 @@ if TYPE_CHECKING:
 
     from .transformers._base import ComponentReducerMixin
     from .types import DataLike
-
-
-@overload
-def _validate_data(
-    estimator: BaseEstimator,
-    *,
-    X: DataLike,
-    y: Literal["no_validation"] = "no_validation",
-    ensure_all_finite: bool | Literal["allow-nan"] = True,
-    **kwargs,
-) -> NDArray: ...
-@overload
-def _validate_data(
-    estimator: BaseEstimator,
-    *,
-    X: Literal["no_validation"] = "no_validation",
-    y: DataLike,
-    ensure_all_finite: bool | Literal["allow-nan"] = True,
-    **kwargs,
-) -> NDArray: ...
-@overload
-def _validate_data(
-    estimator: BaseEstimator,
-    *,
-    X: DataLike,
-    y: DataLike,
-    ensure_all_finite: bool | Literal["allow-nan"] = True,
-    **kwargs,
-) -> tuple[NDArray, NDArray]: ...
-
-
-def _validate_data(
-    estimator: BaseEstimator,
-    *,
-    X: DataLike | Literal["no_validation"] = "no_validation",
-    y: DataLike | Literal["no_validation"] | None = "no_validation",
-    ensure_all_finite: bool | Literal["allow-nan"] = True,
-    **kwargs,
-) -> NDArray | tuple[NDArray, NDArray]:
-    """
-    Compatibility wrapper around sklearn's _validate_data function.
-
-    scikit-learn >= 1.6.0 moved _validate_data from a method of BaseEstimator to a
-    public utility function. This function wraps the utility function if available,
-    and falls back to the method if not. `force_all_finite` was also renamed to
-    `ensure_all_finite`.
-
-    TODO: Remove when sklearn < 1.6.0 support is dropped.
-    """
-    try:
-        from sklearn.utils.validation import validate_data
-    except ImportError:
-        return estimator._validate_data(
-            X=X, y=y, force_all_finite=ensure_all_finite, **kwargs
-        )
-
-    return validate_data(
-        estimator, X=X, y=y, ensure_all_finite=ensure_all_finite, **kwargs
-    )
 
 
 class DFIndexCrosswalkMixin:
@@ -299,7 +240,7 @@ class TransformedKNeighborsRegressor(BaseEstimator, ABC):
 
     def fit(self, X: DataLike, y: DataLike) -> Self:
         """Fit using transformed feature data."""
-        _validate_data(self, X=X, y=y, ensure_all_finite=True, multi_output=True)
+        validate_data(self, X=X, y=y, ensure_all_finite=True, multi_output=True)
 
         # Set the fitted transformer and apply the transformation which serves
         # as input to the KNeighbors regressor.  If estimators derive any custom

--- a/src/sknnr/transformers/_base.py
+++ b/src/sknnr/transformers/_base.py
@@ -4,9 +4,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.preprocessing import StandardScaler
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, validate_data
 
-from .._base import _validate_data
 from ._cca import CCA
 from ._ccora import CCorA
 
@@ -55,7 +54,7 @@ class StandardScalerWithDOF(StandardScaler):
     def fit(self, X: DataLike, y: DataLike | None = None) -> Self:
         scaler = super().fit(X, y)
 
-        X_arr = _validate_data(
+        X_arr = validate_data(
             self,
             X=X,
             accept_sparse=False,

--- a/src/sknnr/transformers/_cca_transformer.py
+++ b/src/sknnr/transformers/_cca_transformer.py
@@ -4,9 +4,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted
+from sklearn.utils.validation import FLOAT_DTYPES, check_is_fitted, validate_data
 
-from .._base import _validate_data
 from . import ComponentReducerMixin
 from ._cca import CCA
 
@@ -55,7 +54,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     """
 
     def fit(self, X: DataLike, y: DataLike) -> Self:
-        X_arr = _validate_data(
+        X_arr = validate_data(
             self,
             X=X,
             reset=True,
@@ -76,7 +75,7 @@ class CCATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
 
     def transform(self, X: DataLike, y: None = None) -> NDArray[np.float64]:
         check_is_fitted(self)
-        X_arr = _validate_data(
+        X_arr = validate_data(
             self,
             X=X,
             reset=False,

--- a/src/sknnr/transformers/_ccora_transformer.py
+++ b/src/sknnr/transformers/_ccora_transformer.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_is_fitted
+from sklearn.utils.validation import check_is_fitted, validate_data
 
-from .._base import _validate_data
 from . import ComponentReducerMixin, StandardScalerWithDOF
 from ._ccora import CCorA
 
@@ -53,7 +52,7 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
     """
 
     def fit(self, X: DataLike, y: DataLike) -> Self:
-        _, y_arr = _validate_data(self, X=X, y=y, reset=True, multi_output=True)
+        _, y_arr = validate_data(self, X=X, y=y, reset=True, multi_output=True)
         self.scaler_ = StandardScalerWithDOF(ddof=1).fit(X)
 
         if y_arr.ndim == 1:
@@ -67,7 +66,7 @@ class CCorATransformer(ComponentReducerMixin, TransformerMixin, BaseEstimator):
 
     def transform(self, X: DataLike, y: None = None) -> NDArray[np.float64]:
         check_is_fitted(self)
-        _validate_data(self, X=X, reset=False, ensure_all_finite=True)
+        validate_data(self, X=X, reset=False, ensure_all_finite=True)
         return self.scaler_.transform(X) @ self.projector_
 
     def fit_transform(self, X: DataLike, y: DataLike) -> NDArray[np.float64]:

--- a/src/sknnr/transformers/_mahalanobis_transformer.py
+++ b/src/sknnr/transformers/_mahalanobis_transformer.py
@@ -4,9 +4,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
-from sklearn.utils.validation import check_is_fitted
+from sklearn.utils.validation import check_is_fitted, validate_data
 
-from .._base import _validate_data
 from . import StandardScalerWithDOF
 
 if TYPE_CHECKING:
@@ -40,7 +39,7 @@ class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimat
     """
 
     def fit(self, X: DataLike, y: None = None) -> Self:
-        _validate_data(
+        validate_data(
             self, X=X, ensure_all_finite="allow-nan", reset=True, ensure_min_features=2
         )
 
@@ -51,7 +50,7 @@ class MahalanobisTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimat
 
     def transform(self, X: DataLike, y: None = None) -> NDArray[np.float64]:
         check_is_fitted(self)
-        _validate_data(self, X=X, ensure_all_finite="allow-nan", reset=False)
+        validate_data(self, X=X, ensure_all_finite="allow-nan", reset=False)
 
         return self.scaler_.transform(X) @ self.transform_
 

--- a/src/sknnr/transformers/_tree_node_transformer.py
+++ b/src/sknnr/transformers/_tree_node_transformer.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_array, check_is_fitted
+from sklearn.utils.validation import check_array, check_is_fitted, validate_data
 
-from .._base import _validate_data
 from ..utils import (
     get_feature_names_and_dtypes,
     is_categorical_dtype,
@@ -129,7 +128,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
         reg_kwargs: dict[str, Any],
         clf_kwargs: dict[str, Any],
     ) -> Self:
-        X_arr = _validate_data(self, X=X, reset=True)
+        X_arr = validate_data(self, X=X, reset=True)
 
         if y is None:
             msg = (
@@ -177,7 +176,7 @@ class TreeNodeTransformer(TransformerMixin, BaseEstimator, ABC):
 
     def transform(self, X: DataLike) -> NDArray[np.int64]:
         check_is_fitted(self)
-        X_arr = _validate_data(
+        X_arr = validate_data(
             self,
             X=X,
             reset=False,


### PR DESCRIPTION
This is a simple update to pin the runtime version of `scikit-learn` to `>=1.6.0`, which allows removal of the existing `sknnr._base._validate_data` function.

Because the `scikit-learn` tag system was updated at `1.6.0` and the `sknnr` estimators use the `__sklearn_tags__` method to expose these tags, users at `scikit-learn<1.6.0` would not receive the full set of tag information, e.g. at `<1.6.0`
```python
# /// script
# dependencies = [
#   "scikit-learn<1.6.0",
#   "sknnr",
# ]
# ///

from sknnr import GNNRegressor

est = GNNRegressor()
print(est._more_tags())

# {'pairwise': False}
```
whereas at `>=1.6.0`
```python
# /// script
# dependencies = [
#   "scikit-learn>=1.6.0",
#   "sknnr",
# ]
# ///

from sknnr import GNNRegressor

est = GNNRegressor()
print(est.__sklearn_tags__())

# Tags(estimator_type='regressor', target_tags=TargetTags(required=True, one_d_labels=False, two_d_labels=False, positive_only=False, multi_output=True, single_output=True), transformer_tags=None, classifier_tags=None, regressor_tags=RegressorTags(poor_score=False), array_api_support=False, no_validation=False, non_deterministic=False, requires_fit=True, _skip_test=False, input_tags=InputTags(one_d_array=False, two_d_array=True, three_d_array=False, sparse=False, categorical=False, string=False, dict=False, positive_only=False, allow_nan=False, pairwise=False))
```

@aazuspan, I wasn't sure if there was more to do on this beside the update to `1.6.0` and the removal of `_validate_data`.  Maybe a bit cavalier, so let me know if I should be tackling other items in this PR.

Closes #118.