### PR TITLE
Disallow duplicate feature names to avoid hash collisions

### DIFF
--- a/src/sknnr/utils/__init__.py
+++ b/src/sknnr/utils/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -157,10 +158,19 @@ def get_feature_names_and_dtypes(
     --------
     dict[Hashable, DTypeLike] : dict
         The feature names and dtypes of the features in `obj`.
+
+    Raises
+    ------
+    ValueError
+        If duplicate feature names are found in `obj`.
     """
+    names = get_feature_names(obj)
+
+    if len(set(names)) != len(names):
+        name_counts = Counter(names)
+        duplicates = [name for name, count in name_counts.items() if count > 1]
+        raise ValueError(f"Duplicate feature names found: {duplicates}.")
+
     return {
-        name: dtype
-        for name, dtype in zip(
-            get_feature_names(obj), get_feature_dtypes(obj), strict=True
-        )
+        name: dtype for name, dtype in zip(names, get_feature_dtypes(obj), strict=True)
     }

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -268,6 +268,24 @@ def test_treenode_transformer_raises_on_mixed_target(transformer, y_wrapper):
         _ = transformer().fit(X, y)
 
 
+@pytest.mark.parametrize("transformer", TEST_TREE_TRANSFORMERS)
+def test_treenode_transformer_handles_duplicate_target_names(transformer):
+    """
+    Test that TreeNodeTransformer.fit raises an error when duplicate
+    target names are present, but does not raise an error when target names
+    that evaluate to the same string are present but are not actually duplicates.
+    """
+    X = pd.DataFrame(np.random.default_rng().random((2, 2)), columns=["f1", "f2"])
+
+    y = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "a"])
+    with pytest.raises(ValueError, match="Duplicate feature names found: \['a'\]\.$"):
+        _ = transformer().fit(X, y)
+
+    y = pd.DataFrame([[1, 2], [3, 4]], columns=[1, "1"])
+    txfr = transformer().fit(X, y)
+    assert txfr.estimator_type_dict_ == {1: "regression", "1": "regression"}
+
+
 @pytest.mark.parametrize("criterion_reg", ["absolute_error"])
 @pytest.mark.parametrize("criterion_clf", ["entropy"])
 @pytest.mark.parametrize("max_features_reg", ["sqrt", "log2"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 from sknnr.utils import (
     get_feature_dtypes,
     get_feature_names,
+    get_feature_names_and_dtypes,
     is_dataframe_like,
     is_nan_like,
     is_number_like_dtype,
@@ -169,3 +170,17 @@ def test_promoted_feature_dtypes(obj, expected):
 def test_is_numpy_dtypelike(t, expected):
     """Test is_numpy_dtypelike returns expected results."""
     assert is_numpy_dtypelike(t) is expected
+
+
+def test_get_feature_names_and_dtypes_handles_duplicate_names():
+    """
+    Test get_feature_names_and_dtypes raises an error when duplicate
+    feature names are present, but does not raise an error when feature names
+    that evaluate to the same string are present but are not actually duplicates.
+    """
+    df = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "a"])
+    with pytest.raises(ValueError, match="Duplicate feature names found: \\['a'\\]."):
+        get_feature_names_and_dtypes(df)
+
+    df = pd.DataFrame([[1, 2], [3, 4]], columns=[1, "1"])
+    assert get_feature_names_and_dtypes(df) == {1: np.int64, "1": np.int64}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -179,7 +179,7 @@ def test_get_feature_names_and_dtypes_handles_duplicate_names():
     that evaluate to the same string are present but are not actually duplicates.
     """
     df = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "a"])
-    with pytest.raises(ValueError, match="Duplicate feature names found: \\['a'\\]."):
+    with pytest.raises(ValueError, match="Duplicate feature names found: \['a'\]\.$"):
         get_feature_names_and_dtypes(df)
 
     df = pd.DataFrame([[1, 2], [3, 4]], columns=[1, "1"])


### PR DESCRIPTION
Closes #116 by checking for duplicate feature names in `get_feature_names_and_dtypes` which is used by all transformers that inherit from `TreeNodeTransformer`.  Technically, duplicate feature names are allowed in pandas dataframes, but when creating a dictionary to map feature names to dtypes, this can lead to hash collisions.

Note that feature names that evaluate to the same string (e.g. `1` and `"1"`) are still valid feature names as they are stored as distinct keys in the dictionary returned from `get_feature_names_and_dtypes`.

@aazuspan, I added a simple test to check for both the true duplicate case and the pseudo-duplicate case, but let me know if you think the tests need to be expanded beyond this simple test.